### PR TITLE
Require exceptions to be explicitly tested

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Determystic includes bundled validators that can replace parts of a conventional
 
 ## Configuration
 
-You can customize which validators run in your project by adding a `[tool.determystic]` section to your project `pyproject.toml`. The configuration supports enabling bundled validators and excluding specific validators from running.
+You can customize which validators run in your project by adding a `[tool.determystic]` section to your project `pyproject.toml`. The configuration supports enabling bundled validators, excluding specific validators from running, and ignoring generated or vendored paths.
 Generated custom validator metadata is also tracked in this section; the generated validator source files still live under `.determystic/`.
 
 ### Enabling Bundled Validators
@@ -121,6 +121,22 @@ enabled = [
 ```
 
 Use `enabled = ["all"]` to opt into every bundled validator explicitly.
+
+### Ignoring Files And Directories
+
+To skip generated, vendored, or otherwise out-of-scope code across all validators, add project-relative entries to `ignore_paths`:
+
+```toml
+# pyproject.toml
+[tool.determystic]
+ignore_paths = [
+    "generated/",
+    "vendor/client.py",
+    "build/**/*.py"
+]
+```
+
+Directory entries ignore everything below that directory. Glob-style entries are also supported.
 
 ### Excluding Validators
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,41 @@ ignore_paths = [
 
 Directory entries ignore everything below that directory. Glob-style entries are also supported.
 
+### Per-Validator Configuration
+
+Validators can declare an optional Pydantic `BaseModel` config schema. Project config for that validator lives under its isolated validator section:
+
+```toml
+# pyproject.toml
+[tool.determystic.validators.my_custom_validator]
+name = "my_custom_validator"
+validator_path = ".determystic/validations/my_custom_validator.determystic"
+
+[tool.determystic.validators.my_custom_validator.config]
+forbidden_name = "debug_only"
+```
+
+Custom validator traversers expose that schema with `config_model` and accept `config` in `__init__`:
+
+```python
+from pydantic import BaseModel
+from determystic.external import DeterministicTraverser
+
+
+class MyValidatorConfig(BaseModel):
+    forbidden_name: str = "debug"
+
+
+class MyValidator(DeterministicTraverser):
+    config_model = MyValidatorConfig
+
+    def __init__(self, code, filename="<string>", config=None):
+        super().__init__(code, filename, config=config)
+        self.typed_config = config or MyValidatorConfig()
+```
+
+The same `[tool.determystic.validators.<name>.config]` convention is available to bundled validators that declare a config model.
+
 ### Excluding Validators
 
 Custom validators are active by default. To disable a custom validator or override an enabled bundled validator, add it to the `exclude` list:

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Determystic includes bundled validators that can replace parts of a conventional
 | `static_analysis` | **Static Analysis** | Code formatting, style conventions, and type checking | `ruff` + `ty` |
 | `hanging_functions` | **Hanging Functions** | Detects unused functions, methods, classes, arguments, and unreachable code | AST analysis |
 | `function_visibility` | **Function Visibility** | Requires externally used functions/methods before private helpers, and internal helpers to use `_` prefixes | Project import graph + AST analysis |
+| `exception_coverage` | **Exception Coverage** | Requires every production `except` handler to be marked as covered by a test function | Test comment markers + AST analysis |
 | `dynamic_ast` | **Dynamic AST** | Loads and runs custom validators from `.determystic` files | Custom AST traversers |
 
 ## Configuration
@@ -154,6 +155,18 @@ def framework_registered_helper():
 Line comments apply to that line and the next line. Comments on or immediately above a function/class definition apply to that whole definition. `ignore-start[...]` and `ignore-end[...]` suppress a block.
 
 Supported codes include `unused-function`, `unused-method`, `unused-class`, `unused-argument`, `unreachable-code`, `dead-code`, `private-prefix`, `function-order`, and `function-visibility`. Custom validators can also be suppressed by validator name.
+
+### Exception Coverage Markers
+
+The `exception_coverage` bundled validator does not require comments in production code. Instead, add a marker immediately above the test function, or above that test function's decorators, naming the production function and the handled exception types that test covers:
+
+```python
+# determystic: tested-exceptions[my_package.service.load_config: FileNotFoundError, ValueError]
+def test_load_config_handles_missing_or_invalid_file():
+    ...
+```
+
+Use the fully qualified production target, including class names for methods, such as `my_package.worker.Runner.execute`. Exception names may be written as `ValueError` or `module.ValueError`.
 
 ### Agent Selection
 

--- a/determystic/__tests__/agents/test_create_validator.py
+++ b/determystic/__tests__/agents/test_create_validator.py
@@ -11,10 +11,12 @@ from determystic.agents.create_validator import (
     AgentDependencies,
     EditFileInput,
     FinalizeInput,
+    ReadExternalFileInput,
     ReadFileInput,
     RunTestsInput,
     WriteFileInput,
     create_ast_validator,
+    read_external_file,
     stream_create_validator,
 )
 
@@ -381,6 +383,24 @@ def test_clean_function():
         print(f"📊 Created {len(deps.files)} files:")
         for filename, content in deps.files.items():
             print(f"  📄 {filename}: {len(content)} characters")
+
+    # determystic: tested-exceptions[determystic.agents.create_validator.read_external_file: Exception]
+    @pytest.mark.asyncio
+    async def test_read_external_file_reports_read_errors(self):
+        """The read_external_file tool reports failures without raising."""
+        deps = AgentDependencies()
+
+        class MockRunContext:
+            def __init__(self, deps):
+                self.deps = deps
+
+        ctx = cast(RunContext[AgentDependencies], MockRunContext(deps))
+
+        with patch("builtins.open", side_effect=OSError("cannot read")):
+            result = await read_external_file(ctx, ReadExternalFileInput())
+
+        assert "Error reading external.py" in result
+        assert "cannot read" in result
 
 
 if __name__ == "__main__":

--- a/determystic/__tests__/agents/test_local_agent.py
+++ b/determystic/__tests__/agents/test_local_agent.py
@@ -8,6 +8,7 @@ import pytest
 from determystic.agents.local_agent import (
     LocalAgentExecutionError,
     LocalAgentSelectionError,
+    _external_interface,
     _build_prompt,
     _create_validator_with_local_agent,
     select_local_agent,
@@ -78,6 +79,13 @@ def test_build_prompt_uses_local_cli_instructions() -> None:
     assert "read_external_file" not in prompt
     assert "Run the tests to ensure everything works correctly" not in prompt
     assert "tests failed" in prompt
+
+
+# determystic: tested-exceptions[determystic.agents.local_agent._external_interface: OSError]
+def test_external_interface_handles_read_errors() -> None:
+    """The prompt builder can tolerate a missing external interface file."""
+    with patch("pathlib.Path.read_text", side_effect=OSError("missing")):
+        assert _external_interface() == ""
 
 
 def test_create_validator_with_local_agent_retries_failed_tests() -> None:

--- a/determystic/__tests__/cli/test_common.py
+++ b/determystic/__tests__/cli/test_common.py
@@ -53,6 +53,7 @@ def test_enabled_accepts_display_names_and_wildcard() -> None:
         "static_analysis",
         "hanging_functions",
         "function_visibility",
+        "exception_coverage",
     ]
 
 

--- a/determystic/__tests__/cli/test_new_validator.py
+++ b/determystic/__tests__/cli/test_new_validator.py
@@ -1,0 +1,100 @@
+"""Tests for the interactive new-validator command."""
+
+from types import SimpleNamespace
+from typing import Awaitable, Callable, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from determystic.agents.create_validator import AgentDependencies, StreamEvent
+from determystic.agents.local_agent import LocalAgentSelectionError
+from determystic.cli.new_validator import _get_multiline_input, new_validator_command
+
+
+async def _invoke_new_validator_command() -> None:
+    callback = new_validator_command.callback
+    assert callback is not None
+    async_callback = cast(
+        Callable[[object | None], Awaitable[None]],
+        getattr(callback, "__wrapped__"),
+    )
+    await async_callback(None)
+
+
+# determystic: tested-exceptions[determystic.cli.new_validator.new_validator_command: LocalAgentSelectionError]
+@pytest.mark.asyncio
+async def test_new_validator_command_exits_when_agent_selection_fails() -> None:
+    """Local agent selection failures are shown before exiting."""
+    config = SimpleNamespace(settings=SimpleNamespace(validator_agent="codex"))
+
+    with (
+        patch("determystic.cli.new_validator.ProjectConfigManager.load_from_disk", return_value=config),
+        patch(
+            "determystic.cli.new_validator.select_local_agent",
+            side_effect=LocalAgentSelectionError("codex unavailable"),
+        ),
+        patch("determystic.cli.new_validator.sys.exit", side_effect=SystemExit(1)) as mock_exit,
+        patch("determystic.cli.new_validator.console.print") as mock_print,
+    ):
+        with pytest.raises(SystemExit):
+            await _invoke_new_validator_command()
+
+    mock_exit.assert_called_once_with(1)
+    assert "codex unavailable" in str(mock_print.call_args_list[0])
+
+
+# determystic: tested-exceptions[determystic.cli.new_validator.new_validator_command: Exception]
+@pytest.mark.asyncio
+async def test_new_validator_command_reports_save_errors() -> None:
+    """Generated validator save failures are reported without crashing."""
+    config = SimpleNamespace(
+        settings=SimpleNamespace(validator_agent="codex"),
+        validators={},
+        new_validation=MagicMock(side_effect=RuntimeError("disk full")),
+        save_to_disk=MagicMock(),
+    )
+    deps = AgentDependencies()
+    deps.validation_contents = "validator code"
+    deps.test_contents = "test code"
+
+    async def fake_stream_create_validator_with_local_agent(*args, **kwargs):
+        yield StreamEvent(event_type="final_result", content="done", deps=deps)
+
+    with (
+        patch("determystic.cli.new_validator.ProjectConfigManager.load_from_disk", return_value=config),
+        patch("determystic.cli.new_validator.select_local_agent", return_value="codex"),
+        patch("determystic.cli.new_validator._get_multiline_input", new=AsyncMock(return_value="bad code")),
+        patch(
+            "determystic.cli.new_validator.Prompt.ask",
+            side_effect=["detect bad code", "save-error-validator", "y"],
+        ),
+        patch(
+            "determystic.cli.new_validator.stream_create_validator_with_local_agent",
+            new=fake_stream_create_validator_with_local_agent,
+        ),
+        patch("determystic.cli.new_validator.console.print") as mock_print,
+    ):
+        await _invoke_new_validator_command()
+
+    config.save_to_disk.assert_not_called()
+    assert "Error saving validator files: disk full" in str(mock_print.call_args_list)
+
+
+# determystic: tested-exceptions[determystic.cli.new_validator._get_multiline_input: EOFError, KeyboardInterrupt]
+@pytest.mark.asyncio
+async def test_get_multiline_input_handles_terminal_interrupts() -> None:
+    """Prompt interruption returns an empty string."""
+
+    class FailingSession:
+        def __init__(self, exception: BaseException) -> None:
+            self.exception = exception
+
+        async def prompt_async(self):
+            raise self.exception
+
+    for exception in (EOFError(), KeyboardInterrupt()):
+        with patch(
+            "determystic.cli.new_validator.PromptSession",
+            return_value=FailingSession(exception),
+        ):
+            assert await _get_multiline_input("Paste code") == ""

--- a/determystic/__tests__/configs/test_base.py
+++ b/determystic/__tests__/configs/test_base.py
@@ -284,6 +284,33 @@ class TestSaveToDisk:
                 assert saved_data["version"] == "2.0.0"
                 assert saved_data != initial_data
 
+    # determystic: tested-exceptions[determystic.configs.base.BaseConfig.save_to_disk: FileNotFoundError]
+    def test_save_to_disk_uses_first_possible_path_when_config_path_is_missing(self) -> None:
+        """save_to_disk falls back to the first possible path if discovery fails."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            fallback_path = temp_path / "fallback" / "test_config.toml"
+            config = ConcreteTestConfig(name="fallback")
+
+            with (
+                patch.object(
+                    ConcreteTestConfig,
+                    "get_config_path",
+                    side_effect=FileNotFoundError("missing"),
+                ),
+                patch.object(
+                    ConcreteTestConfig,
+                    "get_possible_config_paths",
+                    return_value=[fallback_path],
+                ),
+            ):
+                config.save_to_disk()
+
+            with fallback_path.open("rb") as f:
+                saved_data = tomllib.load(f)
+
+            assert saved_data["name"] == "fallback"
+
     @pytest.mark.parametrize("config_data", [
         {"name": "test", "version": "1.0.0"},
         {"name": "complex", "version": "1.2.3-alpha+build.1"},

--- a/determystic/__tests__/configs/test_project.py
+++ b/determystic/__tests__/configs/test_project.py
@@ -316,6 +316,12 @@ ignore_paths = ["generated/", "vendor/client.py"]
 [tool.determystic.settings]
 debug = true
 validator_agent = "Codex"
+
+[tool.determystic.validators.exception_coverage.config]
+strict = true
+
+[tool.determystic.validators.hanging_functions]
+allowed_names = ["framework_hook"]
 """)
 
             with patch.object(ProjectConfigManager, 'get_possible_config_paths', return_value=[config_file]):
@@ -328,6 +334,11 @@ validator_agent = "Codex"
                 assert config.ignore_paths == ["generated/", "vendor/client.py"]
                 assert config.settings.validator_agent == "codex"
                 assert config.settings.model_extra == {"debug": True}
+                assert config.validators == {}
+                assert config._get_validator_config_data("exception_coverage") == {"strict": True}
+                assert config._get_validator_config_data("hanging_functions") == {
+                    "allowed_names": ["framework_hook"]
+                }
 
     def test_load_from_pyproject_accepts_ignored_paths_alias(self) -> None:
         """The older descriptive ignored_paths key maps to ignore_paths."""
@@ -336,6 +347,75 @@ validator_agent = "Codex"
         )
 
         assert config.ignore_paths == ["generated/"]
+
+    def test_validator_config_model_validation(self) -> None:
+        """Validator config payloads can be validated against caller-provided models."""
+        from pydantic import BaseModel
+
+        class ExampleConfig(BaseModel):
+            threshold: int = 3
+
+        config = ProjectConfigManager.model_validate(
+            {
+                "validators": {
+                    "example": {
+                        "config": {
+                            "threshold": 5,
+                        }
+                    }
+                }
+            }
+        )
+
+        validator_config = config.get_validator_config("example", ExampleConfig)
+
+        assert validator_config.threshold == 5
+
+    def test_custom_validator_config_is_preserved_with_metadata(self) -> None:
+        """Custom validator metadata can carry an isolated config payload."""
+        config = ProjectConfigManager.model_validate(
+            {
+                "validators": {
+                    "custom": {
+                        "name": "custom",
+                        "validator_path": ".determystic/validations/custom.determystic",
+                        "config": {
+                            "forbidden_name": "bad_pattern",
+                        },
+                    }
+                }
+            }
+        )
+
+        assert set(config.validators) == {"custom"}
+        assert config.validators["custom"].config == {"forbidden_name": "bad_pattern"}
+        assert config._get_validator_config_data("custom") == {
+            "forbidden_name": "bad_pattern"
+        }
+
+    def test_save_to_pyproject_serializes_validator_configs_under_validator_sections(self) -> None:
+        """Config-only validator payloads are written under tool.determystic.validators."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            config_file = temp_path / "pyproject.toml"
+            config_file.write_text("")
+
+            with patch.object(ProjectConfigManager, 'get_possible_config_paths', return_value=[config_file]):
+                config = ProjectConfigManager(
+                    validator_configs={
+                        "exception_coverage": {
+                            "strict": True,
+                        }
+                    }
+                )
+                config.save_to_disk()
+
+                with config_file.open("rb") as f:
+                    saved_data = tomllib.load(f)
+
+        assert saved_data["tool"]["determystic"]["validators"]["exception_coverage"]["config"] == {
+            "strict": True
+        }
 
     def test_project_settings_accepts_legacy_agent_alias(self) -> None:
         """Test loading the old agent key into the typed validator_agent setting."""

--- a/determystic/__tests__/configs/test_project.py
+++ b/determystic/__tests__/configs/test_project.py
@@ -311,6 +311,7 @@ version = "2.0"
 project_name = "configured_project"
 exclude = ["Static Analysis"]
 enabled = ["Function Visibility"]
+ignore_paths = ["generated/", "vendor/client.py"]
 
 [tool.determystic.settings]
 debug = true
@@ -324,8 +325,17 @@ validator_agent = "Codex"
                 assert config.project_name == "configured_project"
                 assert config.exclude == ["Static Analysis"]
                 assert config.enabled == ["Function Visibility"]
+                assert config.ignore_paths == ["generated/", "vendor/client.py"]
                 assert config.settings.validator_agent == "codex"
                 assert config.settings.model_extra == {"debug": True}
+
+    def test_load_from_pyproject_accepts_ignored_paths_alias(self) -> None:
+        """The older descriptive ignored_paths key maps to ignore_paths."""
+        config = ProjectConfigManager.model_validate(
+            {"ignored_paths": ["generated/"]}
+        )
+
+        assert config.ignore_paths == ["generated/"]
 
     def test_project_settings_accepts_legacy_agent_alias(self) -> None:
         """Test loading the old agent key into the typed validator_agent setting."""

--- a/determystic/__tests__/configs/test_system.py
+++ b/determystic/__tests__/configs/test_system.py
@@ -82,6 +82,7 @@ class TestDeterministicSettingsClassMethods:
                 assert isinstance(config, DeterministicSettings)
                 assert config.anthropic_api_key == expected_api_key
 
+    # determystic: tested-exceptions[determystic.configs.system.DeterministicSettings.load_from_disk: Exception]
     @pytest.mark.parametrize("exception_type,exception_message", [
         (FileNotFoundError, "Config file not found"),
         (ValueError, "Invalid TOML"),

--- a/determystic/__tests__/test_external.py
+++ b/determystic/__tests__/test_external.py
@@ -1,0 +1,16 @@
+"""Tests for the external validator interface."""
+
+from determystic.external import DeterministicTraverser
+
+
+# determystic: tested-exceptions[determystic.external.DeterministicTraverser.validate: SyntaxError]
+def test_deterministic_traverser_validate_reports_syntax_errors() -> None:
+    """Syntax errors are converted into validation issues."""
+    traverser = DeterministicTraverser("def broken(:\n")
+
+    result = traverser.validate()
+
+    assert not result.is_valid
+    assert result.issues is not None
+    assert len(result.issues) == 1
+    assert "Syntax error" in result.issues[0].message

--- a/determystic/__tests__/test_io.py
+++ b/determystic/__tests__/test_io.py
@@ -1,0 +1,39 @@
+"""Tests for IO utilities."""
+
+import subprocess
+import sys
+import types
+from unittest.mock import patch
+
+import pytest
+
+from determystic.io import detect_git_root, get_determystic_package_path
+
+
+# determystic: tested-exceptions[determystic.io.detect_git_root: CalledProcessError, FileNotFoundError]
+def test_detect_git_root_handles_git_lookup_failures(tmp_path) -> None:
+    """Git discovery returns None when git fails or is unavailable."""
+    with patch(
+        "determystic.io.subprocess.run",
+        side_effect=subprocess.CalledProcessError(1, ["git"]),
+    ):
+        assert detect_git_root(tmp_path) is None
+
+    with patch(
+        "determystic.io.subprocess.run",
+        side_effect=FileNotFoundError("git"),
+    ):
+        assert detect_git_root(tmp_path) is None
+
+
+# determystic: tested-exceptions[determystic.io.get_determystic_package_path: ImportError, AttributeError]
+def test_get_determystic_package_path_reports_resolution_errors() -> None:
+    """Package path resolution wraps import and module shape failures."""
+    with patch.dict(sys.modules, {"determystic": None}):
+        with pytest.raises(RuntimeError, match="Unable to resolve"):
+            get_determystic_package_path()
+
+    fake_module = types.ModuleType("determystic")
+    with patch.dict(sys.modules, {"determystic": fake_module}):
+        with pytest.raises(RuntimeError, match="Unable to resolve"):
+            get_determystic_package_path()

--- a/determystic/__tests__/test_isolated_env.py
+++ b/determystic/__tests__/test_isolated_env.py
@@ -1,0 +1,40 @@
+"""Tests for isolated agent test execution."""
+
+import subprocess
+from unittest.mock import patch
+
+from determystic.isolated_env import IsolatedEnv
+
+
+# determystic: tested-exceptions[determystic.isolated_env.IsolatedEnv.run_tests: TimeoutExpired]
+def test_run_tests_reports_timeouts(tmp_path) -> None:
+    """Timeouts from pytest execution are returned as failed test runs."""
+    env = IsolatedEnv()
+
+    with (
+        patch.object(env, "_create_test_package", return_value=tmp_path),
+        patch(
+            "determystic.isolated_env.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(["pytest"], 30),
+        ),
+    ):
+        success, output = env.run_tests("validator", "tests")
+
+    assert success is False
+    assert output == "Test execution timed out"
+
+
+# determystic: tested-exceptions[determystic.isolated_env.IsolatedEnv.run_tests: Exception]
+def test_run_tests_reports_unexpected_errors() -> None:
+    """Unexpected setup errors are returned as failed test runs."""
+    env = IsolatedEnv()
+
+    with patch.object(
+        env,
+        "_create_test_package",
+        side_effect=RuntimeError("package setup failed"),
+    ):
+        success, output = env.run_tests("validator", "tests")
+
+    assert success is False
+    assert "Unexpected error running tests: package setup failed" in output

--- a/determystic/__tests__/test_path_filters.py
+++ b/determystic/__tests__/test_path_filters.py
@@ -1,6 +1,6 @@
 """Tests for shared path filtering."""
 
-from determystic.path_filters import is_ignored_path, iter_python_files
+from determystic.path_filters import _is_ignored_path, iter_python_files
 
 
 def test_is_ignored_path_matches_project_relative_files_and_directories(tmp_path) -> None:
@@ -11,9 +11,17 @@ def test_is_ignored_path_matches_project_relative_files_and_directories(tmp_path
     target_file = tmp_path / "service.py"
     target_file.write_text("value = 1")
 
-    assert is_ignored_path(generated_file, tmp_path, ["generated/"])
-    assert is_ignored_path(target_file, tmp_path, ["service.py"])
-    assert not is_ignored_path(target_file, tmp_path, ["generated/"])
+    assert _is_ignored_path(generated_file, tmp_path, ["generated/"])
+    assert _is_ignored_path(target_file, tmp_path, ["service.py"])
+    assert not _is_ignored_path(target_file, tmp_path, ["generated/"])
+
+
+# determystic: tested-exceptions[determystic.path_filters._is_ignored_path: ValueError]
+def test_is_ignored_path_returns_false_for_paths_outside_project(tmp_path) -> None:
+    """Paths outside the project are not considered ignored."""
+    outside_path = tmp_path.parent / "outside.py"
+
+    assert not _is_ignored_path(outside_path, tmp_path, ["outside.py"])
 
 
 def test_iter_python_files_respects_ignore_paths_and_test_filter(tmp_path) -> None:

--- a/determystic/__tests__/test_path_filters.py
+++ b/determystic/__tests__/test_path_filters.py
@@ -1,0 +1,39 @@
+"""Tests for shared path filtering."""
+
+from determystic.path_filters import is_ignored_path, iter_python_files
+
+
+def test_is_ignored_path_matches_project_relative_files_and_directories(tmp_path) -> None:
+    """Project-relative file and directory ignore entries match expected paths."""
+    generated_file = tmp_path / "generated" / "client.py"
+    generated_file.parent.mkdir()
+    generated_file.write_text("value = 1")
+    target_file = tmp_path / "service.py"
+    target_file.write_text("value = 1")
+
+    assert is_ignored_path(generated_file, tmp_path, ["generated/"])
+    assert is_ignored_path(target_file, tmp_path, ["service.py"])
+    assert not is_ignored_path(target_file, tmp_path, ["generated/"])
+
+
+def test_iter_python_files_respects_ignore_paths_and_test_filter(tmp_path) -> None:
+    """Python file discovery applies hidden, test, and configured path filters."""
+    (tmp_path / "service.py").write_text("value = 1")
+    (tmp_path / "test_service.py").write_text("value = 1")
+    generated_dir = tmp_path / "generated"
+    generated_dir.mkdir()
+    (generated_dir / "client.py").write_text("value = 1")
+    hidden_dir = tmp_path / ".cache"
+    hidden_dir.mkdir()
+    (hidden_dir / "hidden.py").write_text("value = 1")
+
+    files = {
+        file.relative_to(tmp_path).as_posix()
+        for file in iter_python_files(
+            tmp_path,
+            ["generated/"],
+            include_tests=False,
+        )
+    }
+
+    assert files == {"service.py"}

--- a/determystic/__tests__/test_suppressions.py
+++ b/determystic/__tests__/test_suppressions.py
@@ -1,6 +1,8 @@
 """Tests for shared determystic suppression comments."""
 
 import ast
+import tokenize
+from unittest.mock import patch
 
 from determystic.suppressions import SuppressionComments
 
@@ -65,3 +67,23 @@ def test_used_suppression_is_limited_to_unused_findings() -> None:
 
     assert suppressions.suppresses(1, "unused-function")
     assert not suppressions.suppresses(1, "function-order")
+
+
+# determystic: tested-exceptions[determystic.suppressions.SuppressionComments.from_source: SyntaxError]
+def test_from_source_handles_syntax_errors_when_building_definition_ranges() -> None:
+    """Invalid source should still produce an empty suppression lookup."""
+    suppressions = SuppressionComments.from_source("def broken(:\n")
+
+    assert not suppressions.suppresses(1, "unused-function")
+
+
+# determystic: tested-exceptions[determystic.suppressions.SuppressionComments._parse_source_comments: TokenError]
+def test_parse_source_comments_handles_tokenize_errors() -> None:
+    """Tokenization errors should leave the suppression lookup empty."""
+    with patch(
+        "determystic.suppressions.tokenize.generate_tokens",
+        side_effect=tokenize.TokenError("bad token", (1, 1)),
+    ):
+        suppressions = SuppressionComments.from_source("value = 1")
+
+    assert not suppressions.suppresses(1, "unused-function")

--- a/determystic/__tests__/validators/test_dynamic_ast.py
+++ b/determystic/__tests__/validators/test_dynamic_ast.py
@@ -458,6 +458,31 @@ def test_function():
         assert "regular_code.py" in result.output
         assert "hidden_code.py" not in result.output
 
+    @pytest.mark.asyncio
+    async def test_validate_respects_configured_ignore_paths(
+        self,
+        temp_project_dir: Path,
+        sample_python_code_with_issues: str,
+    ) -> None:
+        """Configured ignore paths exclude Python files from custom validators."""
+        generated_dir = temp_project_dir / "generated"
+        generated_dir.mkdir()
+        ignored_file = generated_dir / "client.py"
+        ignored_file.write_text(sample_python_code_with_issues)
+
+        validator = DynamicASTValidator(
+            name="test_validator",
+            validator_path=Path("dummy"),
+            path=temp_project_dir,
+            ignore_paths=["generated/"],
+        )
+        validator.traverser_class = MockTraverserSingleArg
+
+        result = await validator.validate()
+
+        assert result.success
+        assert "No Python files found" in result.output
+
     def test_display_name_property(self, temp_project_dir: Path) -> None:
         """Test that display_name property formats the name correctly."""
         validator = DynamicASTValidator(

--- a/determystic/__tests__/validators/test_dynamic_ast.py
+++ b/determystic/__tests__/validators/test_dynamic_ast.py
@@ -222,6 +222,7 @@ validator_path = ".determystic/validations/missing.determystic"
         # Should return empty list since file doesn't exist
         assert len(validators) == 0
 
+    # determystic: tested-exceptions[determystic.validators.dynamic_ast.DynamicASTValidator._load_validator_module: Exception]
     def test_load_validator_module_invalid_syntax(self, temp_project_dir: Path) -> None:
         """Test loading a validator module with invalid Python syntax."""
         # Create validator file with invalid syntax
@@ -334,6 +335,32 @@ class NotATraverser:
         # Should pass validation
         assert result.success
         assert "No issues found" in result.output
+
+    # determystic: tested-exceptions[determystic.validators.dynamic_ast.DynamicASTValidator.validate: Exception]
+    @pytest.mark.asyncio
+    async def test_validate_reports_traverser_runtime_errors(
+        self,
+        temp_project_dir: Path,
+    ) -> None:
+        """Per-file traverser errors are reported without aborting validation."""
+        python_file = temp_project_dir / "code.py"
+        python_file.write_text("value = 1")
+
+        class ExplodingTraverser(DeterministicTraverser):
+            def __init__(self, code: str) -> None:
+                raise RuntimeError("boom")
+
+        validator = DynamicASTValidator(
+            name="test_validator",
+            validator_path=Path("dummy"),
+            path=temp_project_dir,
+        )
+        validator.traverser_class = ExplodingTraverser
+
+        result = await validator.validate()
+
+        assert not result.success
+        assert "code.py: Error: boom" in result.output
 
     @pytest.mark.asyncio
     async def test_validate_respects_suppression_comments(

--- a/determystic/__tests__/validators/test_dynamic_ast.py
+++ b/determystic/__tests__/validators/test_dynamic_ast.py
@@ -222,6 +222,106 @@ validator_path = ".determystic/validations/missing.determystic"
         # Should return empty list since file doesn't exist
         assert len(validators) == 0
 
+    @pytest.mark.asyncio
+    async def test_validate_passes_typed_config_to_custom_traverser(
+        self,
+        temp_project_dir: Path,
+    ) -> None:
+        """Custom validators can declare a Pydantic config model."""
+        validator_file = temp_project_dir / ".determystic" / "validations" / "configured.determystic"
+        validator_file.write_text('''
+import ast
+from pydantic import BaseModel
+from determystic.external import DeterministicTraverser
+
+class ConfiguredValidatorConfig(BaseModel):
+    forbidden_name: str = "bad_pattern"
+
+class ConfiguredValidator(DeterministicTraverser):
+    config_model = ConfiguredValidatorConfig
+
+    def __init__(self, code, filename="<string>", config=None):
+        super().__init__(code, filename, config=config)
+        self.typed_config = config or ConfiguredValidatorConfig()
+
+    def visit_Name(self, node):
+        if node.id == self.typed_config.forbidden_name:
+            self.add_error(node, f"Found configured name: {self.typed_config.forbidden_name}")
+        self.generic_visit(node)
+''')
+        config_path = temp_project_dir / "pyproject.toml"
+        config_path.write_text('''
+[tool.determystic]
+version = "1.0"
+[tool.determystic.validators.configured]
+name = "configured"
+validator_path = ".determystic/validations/configured.determystic"
+[tool.determystic.validators.configured.config]
+forbidden_name = "configured_bad"
+''')
+        python_file = temp_project_dir / "code.py"
+        python_file.write_text("""
+def run():
+    configured_bad = 1
+    return configured_bad
+""")
+
+        ProjectConfigManager.runtime_custom_path = None
+        ProjectConfigManager._found_path = None
+        ProjectConfigManager.set_runtime_custom_path(temp_project_dir)
+        config_manager = ProjectConfigManager.load_from_disk()
+        validators = DynamicASTValidator.create_validators(config_manager)
+
+        assert len(validators) == 1
+        result = await validators[0].validate()
+
+        assert not result.success
+        assert "Found configured name: configured_bad" in result.output
+
+    # determystic: tested-exceptions[determystic.validators.dynamic_ast.DynamicASTValidator._load_traverser_config: Exception]
+    @pytest.mark.asyncio
+    async def test_validate_reports_invalid_custom_validator_config(
+        self,
+        temp_project_dir: Path,
+    ) -> None:
+        """Invalid config_model payloads fail validation with a clear result."""
+        validator_file = temp_project_dir / ".determystic" / "validations" / "configured.determystic"
+        validator_file.write_text('''
+from pydantic import BaseModel
+from determystic.external import DeterministicTraverser
+
+class ConfiguredValidatorConfig(BaseModel):
+    threshold: int
+
+class ConfiguredValidator(DeterministicTraverser):
+    config_model = ConfiguredValidatorConfig
+''')
+        config_path = temp_project_dir / "pyproject.toml"
+        config_path.write_text('''
+[tool.determystic]
+version = "1.0"
+[tool.determystic.validators.configured]
+name = "configured"
+validator_path = ".determystic/validations/configured.determystic"
+[tool.determystic.validators.configured.config]
+threshold = "not an int"
+''')
+        python_file = temp_project_dir / "code.py"
+        python_file.write_text("value = 1")
+
+        ProjectConfigManager.runtime_custom_path = None
+        ProjectConfigManager._found_path = None
+        ProjectConfigManager.set_runtime_custom_path(temp_project_dir)
+        config_manager = ProjectConfigManager.load_from_disk()
+        validators = DynamicASTValidator.create_validators(config_manager)
+
+        assert len(validators) == 1
+        result = await validators[0].validate()
+
+        assert not result.success
+        assert "Invalid config for validator 'configured'" in result.output
+        assert "threshold" in result.output
+
     # determystic: tested-exceptions[determystic.validators.dynamic_ast.DynamicASTValidator._load_validator_module: Exception]
     def test_load_validator_module_invalid_syntax(self, temp_project_dir: Path) -> None:
         """Test loading a validator module with invalid Python syntax."""

--- a/determystic/__tests__/validators/test_exception_coverage.py
+++ b/determystic/__tests__/validators/test_exception_coverage.py
@@ -1,0 +1,226 @@
+"""Tests for exception coverage validator functionality."""
+
+import tempfile
+import tokenize
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from determystic.configs.project import ProjectConfigManager
+from determystic.validators.exception_coverage import (
+    ExceptionCoverageValidator,
+    _parse_test_markers,
+)
+
+
+class TestExceptionCoverageValidator:
+    """Test suite for ExceptionCoverageValidator."""
+
+    @pytest.fixture
+    def temp_project_dir(self):
+        """Create a temporary project directory."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            yield Path(temp_dir)
+
+    def test_create_validators(self, temp_project_dir: Path) -> None:
+        """Test create_validators factory method."""
+        config_path = temp_project_dir / "pyproject.toml"
+        config_path.write_text("""
+[tool.determystic]
+version = "1.0"
+""")
+
+        ProjectConfigManager.runtime_custom_path = None
+        ProjectConfigManager._found_path = None
+        ProjectConfigManager.set_runtime_custom_path(temp_project_dir)
+        config_manager = ProjectConfigManager.load_from_disk()
+
+        validators = ExceptionCoverageValidator.create_validators(config_manager)
+
+        assert len(validators) == 1
+        assert isinstance(validators[0], ExceptionCoverageValidator)
+        assert validators[0].name == "exception_coverage"
+
+    @pytest.mark.asyncio
+    async def test_validate_passes_when_except_handler_has_test_marker(
+        self,
+        temp_project_dir: Path,
+    ) -> None:
+        """A matching test marker satisfies a production except handler."""
+        (temp_project_dir / "service.py").write_text("""
+def load_config():
+    try:
+        return read_config()
+    except FileNotFoundError:
+        return {}
+""")
+        (temp_project_dir / "test_service.py").write_text("""
+# determystic: tested-exceptions[service.load_config: FileNotFoundError]
+def test_load_config_handles_missing_file():
+    assert True
+""")
+
+        validator = ExceptionCoverageValidator(path=temp_project_dir)
+        result = await validator.validate()
+
+        assert result.success
+        assert result.output == "All except handlers are marked as tested"
+
+    @pytest.mark.asyncio
+    async def test_validate_flags_missing_test_marker(
+        self,
+        temp_project_dir: Path,
+    ) -> None:
+        """An unmarked production except handler is reported."""
+        (temp_project_dir / "service.py").write_text("""
+def load_config():
+    try:
+        return read_config()
+    except FileNotFoundError:
+        return {}
+""")
+        (temp_project_dir / "test_service.py").write_text("""
+def test_load_config_handles_missing_file():
+    assert True
+""")
+
+        validator = ExceptionCoverageValidator(path=temp_project_dir)
+        result = await validator.validate()
+
+        assert not result.success
+        assert "service.py:5:" in result.output
+        assert "service.load_config" in result.output
+        assert "FileNotFoundError" in result.output
+
+    @pytest.mark.asyncio
+    async def test_validate_requires_each_exception_in_tuple_handler(
+        self,
+        temp_project_dir: Path,
+    ) -> None:
+        """Tuple handlers require coverage markers for each listed exception."""
+        (temp_project_dir / "service.py").write_text("""
+def load_config():
+    try:
+        return read_config()
+    except (FileNotFoundError, ValueError):
+        return {}
+""")
+        (temp_project_dir / "test_service.py").write_text("""
+# determystic: tested-exceptions[service.load_config: FileNotFoundError]
+def test_load_config_handles_missing_file():
+    assert True
+""")
+
+        validator = ExceptionCoverageValidator(path=temp_project_dir)
+        result = await validator.validate()
+
+        assert not result.success
+        assert "ValueError" in result.output
+        assert "FileNotFoundError' in service.load_config is not marked" not in result.output
+
+    @pytest.mark.asyncio
+    async def test_validate_accepts_marker_above_decorator(
+        self,
+        temp_project_dir: Path,
+    ) -> None:
+        """Markers can sit above decorators attached to the test function."""
+        (temp_project_dir / "service.py").write_text("""
+async def fetch():
+    try:
+        return await request()
+    except TimeoutError:
+        return None
+""")
+        (temp_project_dir / "test_service.py").write_text("""
+import pytest
+
+# determystic: tested-exceptions[service.fetch: TimeoutError]
+@pytest.mark.asyncio
+async def test_fetch_handles_timeout():
+    assert True
+""")
+
+        validator = ExceptionCoverageValidator(path=temp_project_dir)
+        result = await validator.validate()
+
+        assert result.success
+
+    @pytest.mark.asyncio
+    async def test_validate_flags_stale_test_markers(
+        self,
+        temp_project_dir: Path,
+    ) -> None:
+        """Markers must target an existing except handler."""
+        (temp_project_dir / "service.py").write_text("""
+def load_config():
+    try:
+        return read_config()
+    except FileNotFoundError:
+        return {}
+""")
+        (temp_project_dir / "test_service.py").write_text("""
+# determystic: tested-exceptions[service.load_config: KeyError; service.missing: ValueError]
+def test_load_config_handles_missing_file():
+    assert True
+""")
+
+        validator = ExceptionCoverageValidator(path=temp_project_dir)
+        result = await validator.validate()
+
+        assert not result.success
+        assert "does not catch that exception" in result.output
+        assert "no production function with except handlers matches that name" in result.output
+
+    @pytest.mark.asyncio
+    async def test_validate_requires_marker_above_test_function(
+        self,
+        temp_project_dir: Path,
+    ) -> None:
+        """A marker separated from the test function is not counted."""
+        (temp_project_dir / "service.py").write_text("""
+def load_config():
+    try:
+        return read_config()
+    except FileNotFoundError:
+        return {}
+""")
+        (temp_project_dir / "test_service.py").write_text("""
+# determystic: tested-exceptions[service.load_config: FileNotFoundError]
+
+def test_load_config_handles_missing_file():
+    assert True
+""")
+
+        validator = ExceptionCoverageValidator(path=temp_project_dir)
+        result = await validator.validate()
+
+        assert not result.success
+        assert "must be immediately above a test function" in result.output
+
+    # determystic: tested-exceptions[determystic.validators.exception_coverage.ExceptionCoverageValidator._parse_python_file: SyntaxError, UnicodeDecodeError]
+    def test_parse_python_file_skips_unparseable_files(self, tmp_path: Path) -> None:
+        """The validator skips files it cannot parse as Python source."""
+        syntax_error_file = tmp_path / "bad.py"
+        syntax_error_file.write_text("def broken(:\n")
+        unicode_error_file = tmp_path / "not_utf8.py"
+        unicode_error_file.write_bytes(b"\xff")
+
+        validator = ExceptionCoverageValidator(path=tmp_path)
+
+        assert validator._parse_python_file(syntax_error_file) is None
+        assert validator._parse_python_file(unicode_error_file) is None
+
+
+# determystic: tested-exceptions[determystic.validators.exception_coverage._parse_test_markers: TokenError]
+def test_parse_test_markers_handles_tokenize_errors() -> None:
+    """Tokenization failures are reported as marker parse issues."""
+    with patch(
+        "determystic.validators.exception_coverage.tokenize.generate_tokens",
+        side_effect=tokenize.TokenError("bad token", (1, 1)),
+    ):
+        markers = _parse_test_markers("def test_example():\n    pass\n")
+
+    assert len(markers) == 1
+    assert markers[0].error is not None
+    assert "tokenization failed" in markers[0].error

--- a/determystic/__tests__/validators/test_exception_coverage.py
+++ b/determystic/__tests__/validators/test_exception_coverage.py
@@ -198,6 +198,31 @@ def test_load_config_handles_missing_file():
         assert not result.success
         assert "must be immediately above a test function" in result.output
 
+    @pytest.mark.asyncio
+    async def test_validate_respects_configured_ignore_paths(
+        self,
+        temp_project_dir: Path,
+    ) -> None:
+        """Configured ignore paths exclude production and test files."""
+        generated_dir = temp_project_dir / "generated"
+        generated_dir.mkdir()
+        (generated_dir / "service.py").write_text("""
+def load_config():
+    try:
+        return read_config()
+    except FileNotFoundError:
+        return {}
+""")
+
+        validator = ExceptionCoverageValidator(
+            path=temp_project_dir,
+            ignore_paths=["generated/"],
+        )
+        result = await validator.validate()
+
+        assert result.success
+        assert result.output == "All except handlers are marked as tested"
+
     # determystic: tested-exceptions[determystic.validators.exception_coverage.ExceptionCoverageValidator._parse_python_file: SyntaxError, UnicodeDecodeError]
     def test_parse_python_file_skips_unparseable_files(self, tmp_path: Path) -> None:
         """The validator skips files it cannot parse as Python source."""

--- a/determystic/__tests__/validators/test_function_visibility.py
+++ b/determystic/__tests__/validators/test_function_visibility.py
@@ -1,7 +1,9 @@
 """Tests for function visibility validator functionality."""
 
 import tempfile
+import tomllib
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -212,6 +214,51 @@ def public_api():
 
         assert result.success
         assert result.output == "No Python files found"
+
+    # determystic: tested-exceptions[determystic.validators.function_visibility.FunctionVisibilityValidator._build_project_index: SyntaxError, UnicodeDecodeError]
+    def test_build_project_index_skips_unparseable_files(
+        self,
+        temp_project_dir: Path,
+    ) -> None:
+        """Project indexing skips files that cannot be parsed as Python."""
+        bad_syntax_file = temp_project_dir / "bad_syntax.py"
+        bad_syntax_file.write_text("def broken(:\n")
+        bad_unicode_file = temp_project_dir / "bad_unicode.py"
+        bad_unicode_file.write_bytes(b"\xff")
+        good_file = temp_project_dir / "service.py"
+        good_file.write_text("""
+def public_api():
+    return "ok"
+""")
+
+        validator = FunctionVisibilityValidator(path=temp_project_dir)
+        index = validator._build_project_index(
+            [bad_syntax_file, bad_unicode_file, good_file]
+        )
+
+        assert list(index.modules_by_path) == ["service.py"]
+
+    # determystic: tested-exceptions[determystic.validators.function_visibility.FunctionVisibilityValidator._get_script_entrypoints: TOMLDecodeError, KeyError, ValueError]
+    def test_get_script_entrypoints_handles_pyproject_parse_errors(
+        self,
+        temp_project_dir: Path,
+    ) -> None:
+        """Malformed entrypoint configuration is treated as no entrypoints."""
+        pyproject_file = temp_project_dir / "pyproject.toml"
+        pyproject_file.write_text("[project]\n")
+        validator = FunctionVisibilityValidator(path=temp_project_dir)
+
+        parse_errors = [
+            tomllib.TOMLDecodeError("bad toml", "bad", 0),
+            KeyError("scripts"),
+            ValueError("bad script"),
+        ]
+        for parse_error in parse_errors:
+            with patch(
+                "determystic.validators.function_visibility.tomllib.load",
+                side_effect=parse_error,
+            ):
+                assert validator._get_script_entrypoints(temp_project_dir) == set()
 
     @pytest.mark.asyncio
     async def test_validate_respects_function_visibility_suppression_block(

--- a/determystic/__tests__/validators/test_function_visibility.py
+++ b/determystic/__tests__/validators/test_function_visibility.py
@@ -215,6 +215,32 @@ def public_api():
         assert result.success
         assert result.output == "No Python files found"
 
+    @pytest.mark.asyncio
+    async def test_validate_respects_configured_ignore_paths(
+        self,
+        temp_project_dir: Path,
+    ) -> None:
+        """Configured ignore paths exclude Python files from visibility analysis."""
+        generated_dir = temp_project_dir / "generated"
+        generated_dir.mkdir()
+        (generated_dir / "service.py").write_text("""
+def helper():
+    return "ok"
+
+
+def public_api():
+    return helper()
+""")
+
+        validator = FunctionVisibilityValidator(
+            path=temp_project_dir,
+            ignore_paths=["generated/"],
+        )
+        result = await validator.validate()
+
+        assert result.success
+        assert result.output == "No Python files found"
+
     # determystic: tested-exceptions[determystic.validators.function_visibility.FunctionVisibilityValidator._build_project_index: SyntaxError, UnicodeDecodeError]
     def test_build_project_index_skips_unparseable_files(
         self,

--- a/determystic/__tests__/validators/test_hanging_functions.py
+++ b/determystic/__tests__/validators/test_hanging_functions.py
@@ -301,6 +301,27 @@ version = "1.0"
         assert result.output.count("hanging_function") == 1
 
     @pytest.mark.asyncio
+    async def test_validate_respects_configured_ignore_paths(
+        self,
+        temp_project_dir: Path,
+        sample_code_with_hanging_function: str,
+    ) -> None:
+        """Configured ignore paths exclude Python files from dead-code analysis."""
+        generated_dir = temp_project_dir / "generated"
+        generated_dir.mkdir()
+        ignored_file = generated_dir / "client.py"
+        ignored_file.write_text(sample_code_with_hanging_function)
+
+        validator = HangingFunctionsValidator(
+            path=temp_project_dir,
+            ignore_paths=["generated/"],
+        )
+        result = await validator.validate()
+
+        assert result.success
+        assert "No Python files found" in result.output
+
+    @pytest.mark.asyncio
     async def test_validate_with_script_entrypoints(
         self, 
         temp_project_dir: Path,

--- a/determystic/__tests__/validators/test_hanging_functions.py
+++ b/determystic/__tests__/validators/test_hanging_functions.py
@@ -1,7 +1,9 @@
 """Tests for hanging functions validator functionality."""
 
 import tempfile
+import tomllib
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -335,6 +337,28 @@ def hanging_function():
         assert "cli" not in result.output
         assert "entry_point" not in result.output
 
+    # determystic: tested-exceptions[determystic.validators.hanging_functions.HangingFunctionsValidator._get_script_entrypoints: TOMLDecodeError, KeyError, ValueError]
+    def test_get_script_entrypoints_handles_pyproject_parse_errors(
+        self,
+        temp_project_dir: Path,
+    ) -> None:
+        """Malformed entrypoint configuration is treated as no entrypoints."""
+        pyproject_file = temp_project_dir / "pyproject.toml"
+        pyproject_file.write_text("[project]\n")
+        validator = HangingFunctionsValidator(path=temp_project_dir)
+
+        parse_errors = [
+            tomllib.TOMLDecodeError("bad toml", "bad", 0),
+            KeyError("scripts"),
+            ValueError("bad script"),
+        ]
+        for parse_error in parse_errors:
+            with patch(
+                "determystic.validators.hanging_functions.tomllib.load",
+                side_effect=parse_error,
+            ):
+                assert validator._get_script_entrypoints(temp_project_dir) == set()
+
     @pytest.mark.asyncio
     async def test_validate_no_python_files(self, temp_project_dir: Path) -> None:
         """Test validation when there are no Python files."""
@@ -345,6 +369,7 @@ def hanging_function():
         assert result.success
         assert "No Python files found" in result.output
 
+    # determystic: tested-exceptions[determystic.validators.hanging_functions.HangingFunctionsValidator.validate: SyntaxError, UnicodeDecodeError]
     @pytest.mark.asyncio
     async def test_validate_syntax_error_in_file(
         self, 
@@ -354,6 +379,9 @@ def hanging_function():
         # Create file with syntax error
         bad_file = temp_project_dir / "bad_syntax.py"
         bad_file.write_text("def broken_function(\n    # Missing closing parenthesis")
+
+        bad_unicode_file = temp_project_dir / "bad_unicode.py"
+        bad_unicode_file.write_bytes(b"\xff")
         
         # Create valid file with hanging function
         good_file = temp_project_dir / "good_file.py"

--- a/determystic/__tests__/validators/test_static_analysis.py
+++ b/determystic/__tests__/validators/test_static_analysis.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from pathlib import Path
+from typing import cast
 from unittest.mock import AsyncMock, patch, MagicMock
 import pytest
 
@@ -55,7 +56,10 @@ class TestStaticAnalysisValidator:
 
         validators = StaticAnalysisValidator.create_validators(mock_config_manager)
 
-        assert validators[0].command == [
+        ruff_validator = cast(StaticAnalysisValidator, validators[0])
+        ty_validator = cast(StaticAnalysisValidator, validators[1])
+
+        assert ruff_validator.command == [
             "ruff",
             "check",
             str(path),
@@ -66,7 +70,7 @@ class TestStaticAnalysisValidator:
             "vendor/client.py",
             "--force-exclude",
         ]
-        assert validators[1].command == [
+        assert ty_validator.command == [
             "ty",
             "check",
             str(path),

--- a/determystic/__tests__/validators/test_static_analysis.py
+++ b/determystic/__tests__/validators/test_static_analysis.py
@@ -29,6 +29,7 @@ class TestStaticAnalysisValidator:
         # Mock ProjectConfigManager
         mock_config_manager = MagicMock(spec=ProjectConfigManager)
         mock_config_manager.project_root = path
+        mock_config_manager.ignore_paths = []
         
         validators = StaticAnalysisValidator.create_validators(mock_config_manager)
         
@@ -43,6 +44,38 @@ class TestStaticAnalysisValidator:
         ty_validator = validators[1]
         assert isinstance(ty_validator, StaticAnalysisValidator)
         assert ty_validator.command == ["ty", "check", str(path)]
+
+    def test_create_validators_passes_ignore_paths_to_tools(self) -> None:
+        """Configured ignore paths are translated to external tool excludes."""
+        path = Path("/test/path")
+
+        mock_config_manager = MagicMock(spec=ProjectConfigManager)
+        mock_config_manager.project_root = path
+        mock_config_manager.ignore_paths = ["generated/", "vendor/client.py"]
+
+        validators = StaticAnalysisValidator.create_validators(mock_config_manager)
+
+        assert validators[0].command == [
+            "ruff",
+            "check",
+            str(path),
+            "--no-fix",
+            "--extend-exclude",
+            "generated/",
+            "--extend-exclude",
+            "vendor/client.py",
+            "--force-exclude",
+        ]
+        assert validators[1].command == [
+            "ty",
+            "check",
+            str(path),
+            "--exclude",
+            "generated/",
+            "--exclude",
+            "vendor/client.py",
+            "--force-exclude",
+        ]
 
     @pytest.mark.asyncio
     async def test_validate_success(self) -> None:

--- a/determystic/cli/common.py
+++ b/determystic/cli/common.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 from determystic.configs.project import ProjectConfigManager
 from determystic.validators import (
     DynamicASTValidator,
+    ExceptionCoverageValidator,
     FunctionVisibilityValidator,
     HangingFunctionsValidator,
     StaticAnalysisValidator,
@@ -17,6 +18,7 @@ BUNDLED_VALIDATOR_NAMES = {
     "static_analysis",
     "hanging_functions",
     "function_visibility",
+    "exception_coverage",
 }
 
 
@@ -57,6 +59,7 @@ def create_all_validators(project_config: ProjectConfigManager) -> list["BaseVal
         *StaticAnalysisValidator.create_validators(project_config),
         *HangingFunctionsValidator.create_validators(project_config),
         *FunctionVisibilityValidator.create_validators(project_config),
+        *ExceptionCoverageValidator.create_validators(project_config),
     ]
     
     return validators

--- a/determystic/cli/list_validators.py
+++ b/determystic/cli/list_validators.py
@@ -112,6 +112,8 @@ def list_validators_command(path: Path | None):
                 description = "Detect unused definitions and unreachable code"
             elif "function_visibility" in validator.name:
                 description = "Enforce public-before-private function layout"
+            elif "exception_coverage" in validator.name:
+                description = "Require test markers for except handlers"
             else:
                 description = f"Built-in {validator.display_name} validator"
         

--- a/determystic/configs/project.py
+++ b/determystic/configs/project.py
@@ -2,7 +2,7 @@
 
 import tomllib
 from datetime import datetime
-from typing import Any, ClassVar, Literal
+from typing import Any, ClassVar, Literal, TypeVar
 from pathlib import Path
 
 import tomli_w
@@ -11,6 +11,15 @@ from determystic.configs.base import BaseConfig
 from determystic.io import detect_git_root, detect_pyproject_path
 
 ValidatorAgentPreference = Literal["auto", "codex", "claude"]
+ConfigModelT = TypeVar("ConfigModelT", bound=BaseModel)
+VALIDATOR_METADATA_FIELDS = {
+    "name",
+    "validator_path",
+    "test_path",
+    "created_at",
+    "description",
+    "config",
+}
 
 
 class ValidatorFile(BaseModel):
@@ -20,6 +29,10 @@ class ValidatorFile(BaseModel):
     test_path: str | None = Field(default=None, description="Relative path to the test file")
     created_at: datetime = Field(default_factory=datetime.now)
     description: str | None = Field(default=None, description="Description of what this validator checks")
+    config: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Validator-specific configuration payload.",
+    )
 
 
 class ProjectSettings(BaseModel):
@@ -80,6 +93,11 @@ class ProjectConfigManager(BaseConfig):
         default_factory=dict,
         description="Map of validator names to their file information"
     )
+    validator_configs: dict[str, dict[str, Any]] = Field(
+        default_factory=dict,
+        exclude=True,
+        description="Internal map of validator names to typed configuration payloads.",
+    )
     
     # Project settings
     settings: ProjectSettings = Field(
@@ -91,14 +109,58 @@ class ProjectConfigManager(BaseConfig):
 
     @model_validator(mode="before")
     @classmethod
-    def migrate_ignore_paths_alias(cls, data: Any) -> Any:
-        """Accept the descriptive `ignored_paths` alias for `ignore_paths`."""
+    def migrate_project_config(cls, data: Any) -> Any:
+        """Normalize project config aliases and split validator metadata from config."""
         if not isinstance(data, dict):
             return data
 
         values = dict(data)
         if "ignore_paths" not in values and "ignored_paths" in values:
             values["ignore_paths"] = values.pop("ignored_paths")
+        values = cls._split_validator_config_sections(values)
+        return values
+
+    @staticmethod
+    def _split_validator_config_sections(values: dict[str, Any]) -> dict[str, Any]:
+        raw_validators = values.get("validators")
+        if not isinstance(raw_validators, dict):
+            return values
+
+        custom_validators: dict[str, Any] = {}
+        validator_configs = dict(values.get("validator_configs", {}))
+
+        for validator_name, raw_entry in raw_validators.items():
+            if not isinstance(raw_entry, dict):
+                custom_validators[validator_name] = raw_entry
+                continue
+
+            entry = dict(raw_entry)
+            nested_config = entry.get("config", {})
+            if not isinstance(nested_config, dict):
+                nested_config = {}
+
+            direct_config = {
+                key: value
+                for key, value in entry.items()
+                if key not in VALIDATOR_METADATA_FIELDS
+            }
+            combined_config = {**direct_config, **nested_config}
+            if combined_config:
+                validator_configs[validator_name] = combined_config
+
+            if "validator_path" not in entry:
+                continue
+
+            custom_validators[validator_name] = {
+                key: value
+                for key, value in entry.items()
+                if key in VALIDATOR_METADATA_FIELDS
+            }
+            if combined_config:
+                custom_validators[validator_name]["config"] = combined_config
+
+        values["validators"] = custom_validators
+        values["validator_configs"] = validator_configs
         return values
 
     @classmethod
@@ -167,7 +229,22 @@ class ProjectConfigManager(BaseConfig):
                 pyproject_data = tomllib.load(f)
 
         tool_data = pyproject_data.setdefault("tool", {})
-        tool_data[self.TOOL_SECTION] = self.model_dump(mode="json", exclude_none=True)
+        determystic_data = self.model_dump(
+            mode="json",
+            exclude_none=True,
+            exclude={"validator_configs"},
+        )
+        validators_data = dict(determystic_data.get("validators", {}))
+        for validator_name, validator_config in self.validator_configs.items():
+            if not validator_config:
+                continue
+            validator_data = dict(validators_data.get(validator_name, {}))
+            validator_data["config"] = validator_config
+            validators_data[validator_name] = validator_data
+        if validators_data:
+            determystic_data["validators"] = validators_data
+
+        tool_data[self.TOOL_SECTION] = determystic_data
 
         with config_path.open("wb") as f:
             tomli_w.dump(pyproject_data, f)
@@ -232,9 +309,25 @@ class ProjectConfigManager(BaseConfig):
             return path
         return self.project_root / path
 
+    def get_validator_config(
+        self,
+        name: str,
+        config_model: type[ConfigModelT],
+    ) -> ConfigModelT:
+        """Validate project config for a validator against a Pydantic model."""
+        return config_model.model_validate(self._get_validator_config_data(name))
+
     @property
     def project_root(self) -> Path:
         """
         Get the project root.
         """
         return self.get_config_path().parent
+
+    def _get_validator_config_data(self, name: str) -> dict[str, Any]:
+        """Return raw per-validator configuration for a validator name."""
+        config_data = dict(self.validator_configs.get(name, {}))
+        validator_file = self.validators.get(name)
+        if validator_file is not None:
+            config_data.update(validator_file.config)
+        return config_data

--- a/determystic/configs/project.py
+++ b/determystic/configs/project.py
@@ -70,6 +70,10 @@ class ProjectConfigManager(BaseConfig):
         default_factory=list,
         description="List of bundled validators to enable. Custom validators are enabled by default.",
     )
+    ignore_paths: list[str] = Field(
+        default_factory=list,
+        description="Project-relative files, directories, or glob patterns to ignore during validation.",
+    )
     
     # Validator files tracking
     validators: dict[str, ValidatorFile] = Field(
@@ -84,6 +88,18 @@ class ProjectConfigManager(BaseConfig):
     )
 
     runtime_custom_path: ClassVar[Path | None] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_ignore_paths_alias(cls, data: Any) -> Any:
+        """Accept the descriptive `ignored_paths` alias for `ignore_paths`."""
+        if not isinstance(data, dict):
+            return data
+
+        values = dict(data)
+        if "ignore_paths" not in values and "ignored_paths" in values:
+            values["ignore_paths"] = values.pop("ignored_paths")
+        return values
 
     @classmethod
     def set_runtime_custom_path(cls, path: Path) -> None:

--- a/determystic/external.py
+++ b/determystic/external.py
@@ -6,6 +6,9 @@ validators should use for consistent error reporting and validation results.
 
 import ast
 from dataclasses import dataclass
+from typing import ClassVar
+
+from pydantic import BaseModel
 
 
 @dataclass
@@ -156,17 +159,27 @@ class DeterministicTraverser(ast.NodeVisitor):
     
     This class provides a structured way to traverse the AST and collect
     validation errors with proper line numbers and code context.
+    Set ``config_model`` to a Pydantic ``BaseModel`` subclass to receive typed
+    project configuration from ``[tool.determystic.validators.<name>.config]``.
     """
+    config_model: ClassVar[type[BaseModel] | None] = None
     
-    def __init__(self, code: str, filename: str = "<string>"):
+    def __init__(
+        self,
+        code: str,
+        filename: str = "<string>",
+        config: BaseModel | None = None,
+    ):
         """Initialize the traverser.
         
         Args:
             code: The source code being validated
             filename: Name of the file being validated
+            config: Optional typed validator configuration
         """
         self.code = code
         self.filename = filename
+        self.config = config
         self.errors: list[ValidationIssue] = []
         self._lines = code.split('\n')
     

--- a/determystic/path_filters.py
+++ b/determystic/path_filters.py
@@ -18,18 +18,10 @@ def iter_python_files(
     return [
         py_file
         for py_file in project_root.rglob("*.py")
-        if is_relevant_python_file(py_file)
-        and not is_ignored_path(py_file, project_root, ignore_paths)
+        if _is_relevant_python_file(py_file)
+        and not _is_ignored_path(py_file, project_root, ignore_paths)
         and (include_tests or not is_test_file(py_file))
     ]
-
-
-def is_relevant_python_file(path: Path) -> bool:
-    """Return whether a Python file should be considered before config ignores."""
-    return (
-        not any(part.startswith(".") for part in path.parts)
-        and "__pycache__" not in path.parts
-    )
 
 
 def is_test_file(path: Path) -> bool:
@@ -41,7 +33,15 @@ def is_test_file(path: Path) -> bool:
     )
 
 
-def is_ignored_path(
+def _is_relevant_python_file(path: Path) -> bool:
+    """Return whether a Python file should be considered before config ignores."""
+    return (
+        not any(part.startswith(".") for part in path.parts)
+        and "__pycache__" not in path.parts
+    )
+
+
+def _is_ignored_path(
     path: Path,
     project_root: Path,
     ignore_paths: list[str] | tuple[str, ...] | None,

--- a/determystic/path_filters.py
+++ b/determystic/path_filters.py
@@ -1,0 +1,83 @@
+"""Shared project path filtering for validators."""
+
+from fnmatch import fnmatchcase
+from pathlib import Path
+
+
+TEST_PATH_PARTS = {"tests", "__tests__"}
+GLOB_CHARS = {"*", "?", "["}
+
+
+def iter_python_files(
+    project_root: Path,
+    ignore_paths: list[str] | tuple[str, ...] | None = None,
+    *,
+    include_tests: bool = True,
+) -> list[Path]:
+    """Return Python files that are visible to validators."""
+    return [
+        py_file
+        for py_file in project_root.rglob("*.py")
+        if is_relevant_python_file(py_file)
+        and not is_ignored_path(py_file, project_root, ignore_paths)
+        and (include_tests or not is_test_file(py_file))
+    ]
+
+
+def is_relevant_python_file(path: Path) -> bool:
+    """Return whether a Python file should be considered before config ignores."""
+    return (
+        not any(part.startswith(".") for part in path.parts)
+        and "__pycache__" not in path.parts
+    )
+
+
+def is_test_file(path: Path) -> bool:
+    """Return whether a path is a Python test file or under a test directory."""
+    return (
+        path.name.startswith("test_")
+        or path.name.endswith("_test.py")
+        or any(part in TEST_PATH_PARTS for part in path.parts)
+    )
+
+
+def is_ignored_path(
+    path: Path,
+    project_root: Path,
+    ignore_paths: list[str] | tuple[str, ...] | None,
+) -> bool:
+    """Return whether a project-relative path matches an ignore entry."""
+    if not ignore_paths:
+        return False
+
+    try:
+        relative_path = path.resolve().relative_to(project_root.resolve())
+    except ValueError:
+        return False
+
+    relative = relative_path.as_posix()
+    return any(
+        _matches_ignore_pattern(relative, ignore_path)
+        for ignore_path in ignore_paths
+        if ignore_path.strip()
+    )
+
+
+def _matches_ignore_pattern(relative_path: str, ignore_path: str) -> bool:
+    pattern = _normalize_ignore_pattern(ignore_path)
+    if not pattern:
+        return False
+
+    if any(char in pattern for char in GLOB_CHARS):
+        return fnmatchcase(relative_path, pattern)
+
+    return relative_path == pattern or relative_path.startswith(f"{pattern}/")
+
+
+def _normalize_ignore_pattern(ignore_path: str) -> str:
+    pattern = ignore_path.strip().replace("\\", "/")
+    while pattern.startswith("./"):
+        pattern = pattern[2:]
+    if pattern.startswith("/"):
+        pattern = pattern[1:]
+    return pattern.rstrip("/")

--- a/determystic/validators/__init__.py
+++ b/determystic/validators/__init__.py
@@ -2,4 +2,5 @@ from .dynamic_ast import DynamicASTValidator as DynamicASTValidator
 from .static_analysis import StaticAnalysisValidator as StaticAnalysisValidator
 from .hanging_functions import HangingFunctionsValidator as HangingFunctionsValidator
 from .function_visibility import FunctionVisibilityValidator as FunctionVisibilityValidator
+from .exception_coverage import ExceptionCoverageValidator as ExceptionCoverageValidator
 from .base import BaseValidator as BaseValidator, ValidationResult as ValidationResult

--- a/determystic/validators/base.py
+++ b/determystic/validators/base.py
@@ -3,8 +3,9 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, ClassVar, Dict, Optional
 
+from pydantic import BaseModel
 from determystic.configs.project import ProjectConfigManager
 
 
@@ -19,16 +20,36 @@ class ValidationResult:
 
 class BaseValidator(ABC):
     """Abstract base class for all validators."""
+    config_model: ClassVar[type[BaseModel] | None] = None
     
-    def __init__(self, *, name: str, path: Path | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        name: str,
+        path: Path | None = None,
+        config: BaseModel | None = None,
+    ) -> None:
         """Initialize the validator.
         
         :param name: Name of the validator
         :param path: Optional path to the project/directory being validated
+        :param config: Optional typed validator configuration
 
         """
         self.name = name
         self.path = path or Path.cwd()
+        self.config = config
+
+    @classmethod
+    def parse_config(
+        cls,
+        config_manager: ProjectConfigManager,
+        name: str,
+    ) -> BaseModel | None:
+        """Parse this validator's project config if it declares a config model."""
+        if cls.config_model is None:
+            return None
+        return config_manager.get_validator_config(name, cls.config_model)
     
     @classmethod
     @abstractmethod

--- a/determystic/validators/dynamic_ast.py
+++ b/determystic/validators/dynamic_ast.py
@@ -2,8 +2,9 @@
 
 import inspect
 from pathlib import Path
-from typing import Type
+from typing import Any, Type
 
+from pydantic import BaseModel
 from determystic.configs.project import ProjectConfigManager
 from determystic.external import DeterministicTraverser
 from determystic.path_filters import iter_python_files
@@ -22,11 +23,16 @@ class DynamicASTValidator(BaseValidator):
         validator_path: Path,
         path: Path | None = None,
         ignore_paths: list[str] | None = None,
+        config_data: dict[str, Any] | None = None,
     ) -> None:
         super().__init__(name=name, path=path)
         self.validator_path = validator_path
         self.ignore_paths = ignore_paths or []
+        self.config_data = config_data or {}
         self.traverser_class = self._load_validator_module(validator_path)
+        self.traverser_config: BaseModel | None = None
+        self.config_error: str | None = None
+        self._load_traverser_config()
     
     @classmethod
     def create_validators(cls, config_manager: ProjectConfigManager) -> list["BaseValidator"]:
@@ -46,6 +52,7 @@ class DynamicASTValidator(BaseValidator):
                 validator_path=validator_path,
                 path=config_manager.project_root,
                 ignore_paths=config_manager.ignore_paths,
+                config_data=config_manager._get_validator_config_data(validator_file.name),
             )
             
             # Only add if the traverser class was successfully loaded
@@ -62,6 +69,11 @@ class DynamicASTValidator(BaseValidator):
                 success=False, 
                 output=f"Failed to load validator from {self.validator_path}"
             )
+        if self.config_error is not None:
+            return ValidationResult(
+                success=False,
+                output=f"Invalid config for validator '{self.name}': {self.config_error}",
+            )
         
         # Find all Python files
         python_files = iter_python_files(self.path, self.ignore_paths)
@@ -77,15 +89,7 @@ class DynamicASTValidator(BaseValidator):
                 relative_path = py_file.relative_to(self.path)
                 suppressions = SuppressionComments.from_source(file_content)
                 
-                # Run traverser - check signature to handle different constructor patterns
-                sig = inspect.signature(self.traverser_class.__init__)
-                params = list(sig.parameters.keys())
-                
-                # If it only accepts 'self' and 'code', don't pass filename
-                if len(params) == 2 and 'filename' not in params:
-                    traverser = self.traverser_class(file_content)
-                else:
-                    traverser = self.traverser_class(file_content, str(relative_path))
+                traverser = self._create_traverser(file_content, str(relative_path))
                 
                 result = traverser.validate()
                 
@@ -108,6 +112,46 @@ class DynamicASTValidator(BaseValidator):
         output = "\n\n".join(all_issues) if all_issues else "No issues found"
         
         return ValidationResult(success=success, output=output)
+
+    def _create_traverser(
+        self,
+        file_content: str,
+        relative_path: str,
+    ) -> DeterministicTraverser:
+        assert self.traverser_class is not None
+        sig = inspect.signature(self.traverser_class.__init__)
+        params = sig.parameters
+
+        accepts_filename = "filename" in params
+        accepts_config = "config" in params
+
+        if accepts_filename and accepts_config:
+            return self.traverser_class(
+                file_content,
+                relative_path,
+                config=self.traverser_config,
+            )
+        if accepts_filename:
+            return self.traverser_class(file_content, relative_path)
+        if accepts_config:
+            return self.traverser_class(file_content, config=self.traverser_config)
+        return self.traverser_class(file_content)
+
+    def _load_traverser_config(self) -> None:
+        if self.traverser_class is None:
+            return
+
+        config_model = getattr(self.traverser_class, "config_model", None)
+        if config_model is None:
+            return
+        if not inspect.isclass(config_model) or not issubclass(config_model, BaseModel):
+            self.config_error = "config_model must be a pydantic BaseModel subclass"
+            return
+
+        try:
+            self.traverser_config = config_model.model_validate(self.config_data)
+        except Exception as error:
+            self.config_error = str(error)
     
     def _load_validator_module(self, validator_path: Path) -> Type[DeterministicTraverser] | None:
         """Helper function to load a validator module using importlib and find DeterministicTraverser subclass."""

--- a/determystic/validators/dynamic_ast.py
+++ b/determystic/validators/dynamic_ast.py
@@ -6,6 +6,7 @@ from typing import Type
 
 from determystic.configs.project import ProjectConfigManager
 from determystic.external import DeterministicTraverser
+from determystic.path_filters import iter_python_files
 from determystic.suppressions import SuppressionComments
 from determystic.validators.base import BaseValidator, ValidationResult
 from determystic.logging import CONSOLE
@@ -14,9 +15,17 @@ from determystic.logging import CONSOLE
 class DynamicASTValidator(BaseValidator):
     """Loads and runs custom AST validators from .determystic files."""
     
-    def __init__(self, *, name: str, validator_path: Path, path: Path | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        name: str,
+        validator_path: Path,
+        path: Path | None = None,
+        ignore_paths: list[str] | None = None,
+    ) -> None:
         super().__init__(name=name, path=path)
         self.validator_path = validator_path
+        self.ignore_paths = ignore_paths or []
         self.traverser_class = self._load_validator_module(validator_path)
     
     @classmethod
@@ -35,7 +44,8 @@ class DynamicASTValidator(BaseValidator):
             validator = cls(
                 name=validator_file.name,
                 validator_path=validator_path,
-                path=config_manager.project_root
+                path=config_manager.project_root,
+                ignore_paths=config_manager.ignore_paths,
             )
             
             # Only add if the traverser class was successfully loaded
@@ -54,8 +64,7 @@ class DynamicASTValidator(BaseValidator):
             )
         
         # Find all Python files
-        python_files = list(self.path.rglob("*.py"))
-        python_files = [f for f in python_files if not any(part.startswith('.') for part in f.parts)]
+        python_files = iter_python_files(self.path, self.ignore_paths)
         
         if not python_files:
             return ValidationResult(success=True, output="No Python files found")

--- a/determystic/validators/exception_coverage.py
+++ b/determystic/validators/exception_coverage.py
@@ -1,0 +1,507 @@
+"""Validator that requires except handlers to be marked as tested."""
+
+import ast
+import io
+import tokenize
+from dataclasses import dataclass
+from pathlib import Path
+
+from determystic.configs.project import ProjectConfigManager
+from determystic.validators.base import BaseValidator, ValidationResult
+
+
+MARKER_NAMES = {
+    "tested-exception",
+    "tested-exceptions",
+    "test-exception",
+    "test-exceptions",
+}
+TEST_PATH_PARTS = {"tests", "__tests__"}
+
+
+@dataclass(frozen=True)
+class ExceptionRequirement:
+    """One exception type handled by an except clause in production code."""
+
+    module_path: str
+    line_number: int
+    target: str
+    exception_name: str
+    exception_aliases: frozenset[str]
+
+
+@dataclass(frozen=True)
+class CoverageEntry:
+    """One test marker entry claiming coverage for a production except handler."""
+
+    module_path: str
+    line_number: int
+    test_function: str
+    target: str
+    exception_name: str
+    exception_aliases: frozenset[str]
+
+
+@dataclass(frozen=True)
+class ParsedMarker:
+    """A parsed determystic tested-exceptions comment."""
+
+    line_number: int
+    entries: tuple[tuple[str, str], ...]
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class TestFunction:
+    """A test function and the source line where its leading comments attach."""
+
+    name: str
+    line_number: int
+    comment_anchor_line: int
+
+
+class ExceptionHandlerCollector(ast.NodeVisitor):
+    """Collect except handlers and map them to their enclosing function."""
+
+    def __init__(self, module_path: str, module_name: str) -> None:
+        self.module_path = module_path
+        self.module_name = module_name
+        self.scope_stack: list[str] = []
+        self.requirements: list[ExceptionRequirement] = []
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.scope_stack.append(node.name)
+        self.generic_visit(node)
+        self.scope_stack.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_Try(self, node: ast.Try) -> None:
+        target = self._current_target()
+        for handler in node.handlers:
+            for exception_name, exception_aliases in _handler_exception_names(handler):
+                self.requirements.append(
+                    ExceptionRequirement(
+                        module_path=self.module_path,
+                        line_number=handler.lineno,
+                        target=target,
+                        exception_name=exception_name,
+                        exception_aliases=frozenset(
+                            _normalize_exception_name(alias)
+                            for alias in exception_aliases
+                        ),
+                    )
+                )
+        self.generic_visit(node)
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        self.scope_stack.append(node.name)
+        self.generic_visit(node)
+        self.scope_stack.pop()
+
+    def _current_target(self) -> str:
+        if not self.scope_stack:
+            return f"{self.module_name}.<module>"
+        return ".".join([self.module_name, *self.scope_stack])
+
+
+class TestFunctionCollector(ast.NodeVisitor):
+    """Collect pytest-style test functions from a parsed test module."""
+
+    def __init__(self) -> None:
+        self.class_stack: list[str] = []
+        self.functions: list[TestFunction] = []
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.class_stack.append(node.name)
+        self.generic_visit(node)
+        self.class_stack.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._collect_function(node)
+        self.generic_visit(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._collect_function(node)
+        self.generic_visit(node)
+
+    def _collect_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        if not node.name.startswith("test_"):
+            return
+
+        decorator_lines = [decorator.lineno for decorator in node.decorator_list]
+        anchor_line = min([node.lineno, *decorator_lines])
+        qualified_name = ".".join([*self.class_stack, node.name])
+        self.functions.append(
+            TestFunction(
+                name=qualified_name,
+                line_number=node.lineno,
+                comment_anchor_line=anchor_line,
+            )
+        )
+
+
+class ExceptionCoverageValidator(BaseValidator):
+    """Validator that ensures production except handlers are covered by test markers."""
+
+    def __init__(self, *, name: str = "exception_coverage", path: Path | None = None) -> None:
+        super().__init__(name=name, path=path)
+
+    @classmethod
+    def create_validators(cls, config_manager: ProjectConfigManager) -> list["BaseValidator"]:
+        """Factory function that creates a single exception coverage validator."""
+        return [cls(path=config_manager.project_root)]
+
+    async def validate(self) -> ValidationResult:
+        """Validate exception handler coverage markers across the project."""
+        production_files = self._get_production_python_files(self.path)
+        test_files = self._get_test_python_files(self.path)
+
+        requirements = self._collect_requirements(production_files)
+        coverage_entries, marker_issues = self._collect_test_coverage(test_files)
+        coverage_issues = self._find_coverage_issues(requirements, coverage_entries)
+
+        issues = [*marker_issues, *coverage_issues]
+        if not issues:
+            return ValidationResult(success=True, output="All except handlers are marked as tested")
+
+        return ValidationResult(success=False, output="\n".join(issues))
+
+    def _get_production_python_files(self, path: Path) -> list[Path]:
+        return [
+            py_file
+            for py_file in path.rglob("*.py")
+            if _is_relevant_python_file(py_file) and not _is_test_file(py_file)
+        ]
+
+    def _get_test_python_files(self, path: Path) -> list[Path]:
+        return [
+            py_file
+            for py_file in path.rglob("*.py")
+            if _is_relevant_python_file(py_file) and _is_test_file(py_file)
+        ]
+
+    def _collect_requirements(self, python_files: list[Path]) -> list[ExceptionRequirement]:
+        requirements: list[ExceptionRequirement] = []
+
+        for py_file in python_files:
+            parsed = self._parse_python_file(py_file)
+            if parsed is None:
+                continue
+
+            _, tree = parsed
+            relative_path = str(py_file.relative_to(self.path))
+            collector = ExceptionHandlerCollector(
+                relative_path,
+                _module_name_for_file(py_file, self.path),
+            )
+            collector.visit(tree)
+            requirements.extend(collector.requirements)
+
+        return requirements
+
+    def _collect_test_coverage(
+        self,
+        test_files: list[Path],
+    ) -> tuple[list[CoverageEntry], list[str]]:
+        entries: list[CoverageEntry] = []
+        issues: list[str] = []
+
+        for py_file in test_files:
+            parsed = self._parse_python_file(py_file)
+            if parsed is None:
+                continue
+
+            source, tree = parsed
+            relative_path = str(py_file.relative_to(self.path))
+            markers = _parse_test_markers(source)
+            functions = _test_functions(tree)
+            attached_marker_lines: set[int] = set()
+
+            for marker in markers:
+                if marker.error:
+                    issues.append(
+                        f"{relative_path}:{marker.line_number}: {marker.error}"
+                    )
+
+            for test_function in functions:
+                for comment_line in _leading_comment_block_lines(
+                    source,
+                    test_function.comment_anchor_line,
+                ):
+                    for marker in markers:
+                        if marker.line_number != comment_line or marker.error:
+                            continue
+                        attached_marker_lines.add(marker.line_number)
+                        entries.extend(
+                            CoverageEntry(
+                                module_path=relative_path,
+                                line_number=marker.line_number,
+                                test_function=test_function.name,
+                                target=target,
+                                exception_name=exception_name,
+                                exception_aliases=_exception_aliases(exception_name),
+                            )
+                            for target, exception_name in marker.entries
+                        )
+
+            for marker in markers:
+                if marker.error or marker.line_number in attached_marker_lines:
+                    continue
+                issues.append(
+                    f"{relative_path}:{marker.line_number}: "
+                    "tested-exceptions marker must be immediately above a test function"
+                )
+
+        return entries, issues
+
+    def _find_coverage_issues(
+        self,
+        requirements: list[ExceptionRequirement],
+        coverage_entries: list[CoverageEntry],
+    ) -> list[str]:
+        issues: list[str] = []
+        requirements_by_target: dict[str, list[ExceptionRequirement]] = {}
+        coverage_by_target: dict[str, set[str]] = {}
+
+        for requirement in requirements:
+            requirements_by_target.setdefault(requirement.target, []).append(requirement)
+
+        for entry in coverage_entries:
+            coverage_by_target.setdefault(entry.target, set()).update(entry.exception_aliases)
+
+        for requirement in requirements:
+            covered_exceptions = coverage_by_target.get(requirement.target, set())
+            if requirement.exception_aliases & covered_exceptions:
+                continue
+
+            issues.append(
+                f"{requirement.module_path}:{requirement.line_number}: "
+                f"Except handler for '{requirement.exception_name}' in "
+                f"{requirement.target} is not marked as tested. Add a "
+                "tested-exceptions marker above the test function that covers "
+                f"target '{requirement.target}' and exception "
+                f"'{requirement.exception_name}'."
+            )
+
+        for entry in coverage_entries:
+            target_requirements = requirements_by_target.get(entry.target)
+            if target_requirements is None:
+                issues.append(
+                    f"{entry.module_path}:{entry.line_number}: "
+                    f"tested-exceptions marker in '{entry.test_function}' targets "
+                    f"'{entry.target}', but no production function with except handlers "
+                    "matches that name"
+                )
+                continue
+
+            if any(
+                requirement.exception_aliases & entry.exception_aliases
+                for requirement in target_requirements
+            ):
+                continue
+
+            issues.append(
+                f"{entry.module_path}:{entry.line_number}: "
+                f"tested-exceptions marker in '{entry.test_function}' lists "
+                f"'{entry.exception_name}' for '{entry.target}', but that function "
+                "does not catch that exception"
+            )
+
+        return issues
+
+    def _parse_python_file(self, py_file: Path) -> tuple[str, ast.AST] | None:
+        try:
+            source = py_file.read_text(encoding="utf-8")
+            return source, ast.parse(source, filename=str(py_file))
+        except (SyntaxError, UnicodeDecodeError):
+            return None
+
+
+def _parse_test_markers(source: str) -> list[ParsedMarker]:
+    markers: list[ParsedMarker] = []
+
+    try:
+        tokens = tokenize.generate_tokens(io.StringIO(source).readline)
+        for token in tokens:
+            if token.type != tokenize.COMMENT:
+                continue
+            marker = _parse_marker_comment(token.start[0], token.string)
+            if marker is not None:
+                markers.append(marker)
+    except tokenize.TokenError:
+        return [
+            ParsedMarker(
+                line_number=1,
+                entries=(),
+                error="Could not parse tested-exceptions markers because tokenization failed",
+            )
+        ]
+
+    return markers
+
+
+def _parse_marker_comment(line_number: int, comment: str) -> ParsedMarker | None:
+    marker = "determystic:"
+    marker_index = comment.lower().find(marker)
+    if marker_index == -1:
+        return None
+
+    directive = comment[marker_index + len(marker):].strip()
+    bracket_start = directive.find("[")
+    marker_name = directive[:bracket_start if bracket_start != -1 else None]
+    normalized_marker_name = marker_name.strip().lower().replace("_", "-")
+    if normalized_marker_name not in MARKER_NAMES:
+        return None
+
+    bracket_end = directive.find("]", bracket_start + 1)
+    if bracket_start == -1 or bracket_end == -1:
+        return ParsedMarker(
+            line_number=line_number,
+            entries=(),
+            error=(
+                "Invalid tested-exceptions marker. Expected "
+                "'# determystic: tested-exceptions[module.function: ExceptionName]'"
+            ),
+        )
+
+    body = directive[bracket_start + 1:bracket_end].strip()
+    entries: list[tuple[str, str]] = []
+    errors: list[str] = []
+
+    for raw_entry in body.split(";"):
+        raw_entry = raw_entry.strip()
+        if not raw_entry:
+            continue
+        if ":" not in raw_entry:
+            errors.append(f"'{raw_entry}' is missing ':'")
+            continue
+
+        target, exception_list = raw_entry.split(":", 1)
+        target = target.strip()
+        exception_names = [
+            exception_name.strip()
+            for exception_name in exception_list.split(",")
+            if exception_name.strip()
+        ]
+
+        if not target:
+            errors.append("target function is empty")
+            continue
+        if "." not in target:
+            errors.append(f"'{target}' is not a module.function target")
+            continue
+        if not exception_names:
+            errors.append(f"'{target}' does not list any exceptions")
+            continue
+
+        entries.extend((target, exception_name) for exception_name in exception_names)
+
+    if errors or not entries:
+        return ParsedMarker(
+            line_number=line_number,
+            entries=(),
+            error=f"Invalid tested-exceptions marker: {', '.join(errors) or 'no entries found'}",
+        )
+
+    return ParsedMarker(line_number=line_number, entries=tuple(entries))
+
+
+def _test_functions(tree: ast.AST) -> list[TestFunction]:
+    collector = TestFunctionCollector()
+    collector.visit(tree)
+    return collector.functions
+
+
+def _leading_comment_block_lines(source: str, anchor_line: int) -> list[int]:
+    source_lines = source.splitlines()
+    comment_lines: list[int] = []
+    line_number = anchor_line - 1
+
+    while line_number >= 1:
+        line = source_lines[line_number - 1].strip()
+        if not line:
+            break
+        if not line.startswith("#"):
+            break
+        comment_lines.append(line_number)
+        line_number -= 1
+
+    return comment_lines
+
+
+def _handler_exception_names(handler: ast.ExceptHandler) -> list[tuple[str, set[str]]]:
+    if handler.type is None:
+        return [("BaseException", {"BaseException", "bare"})]
+
+    if isinstance(handler.type, ast.Tuple):
+        return [_exception_name(element) for element in handler.type.elts]
+
+    return [_exception_name(handler.type)]
+
+
+def _exception_name(node: ast.AST) -> tuple[str, set[str]]:
+    if isinstance(node, ast.Name):
+        return node.id, {node.id}
+
+    if isinstance(node, ast.Attribute):
+        dotted_name = _attribute_name(node)
+        simple_name = node.attr
+        return dotted_name, {dotted_name, simple_name}
+
+    unparsed_name = ast.unparse(node)
+    return unparsed_name, {unparsed_name, unparsed_name.rsplit(".", 1)[-1]}
+
+
+def _attribute_name(node: ast.Attribute) -> str:
+    parts = [node.attr]
+    value = node.value
+
+    while isinstance(value, ast.Attribute):
+        parts.append(value.attr)
+        value = value.value
+
+    if isinstance(value, ast.Name):
+        parts.append(value.id)
+    else:
+        parts.append(ast.unparse(value))
+
+    return ".".join(reversed(parts))
+
+
+def _exception_aliases(exception_name: str) -> frozenset[str]:
+    return frozenset(
+        _normalize_exception_name(alias)
+        for alias in {exception_name, exception_name.rsplit(".", 1)[-1]}
+    )
+
+
+def _normalize_exception_name(exception_name: str) -> str:
+    return exception_name.strip().lower()
+
+
+def _module_name_for_file(py_file: Path, project_root: Path) -> str:
+    relative_path = py_file.relative_to(project_root).with_suffix("")
+    parts = list(relative_path.parts)
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts) if parts else py_file.stem
+
+
+def _is_relevant_python_file(py_file: Path) -> bool:
+    return (
+        not any(part.startswith(".") for part in py_file.parts)
+        and "__pycache__" not in py_file.parts
+    )
+
+
+def _is_test_file(py_file: Path) -> bool:
+    return (
+        py_file.name.startswith("test_")
+        or py_file.name.endswith("_test.py")
+        or any(part in TEST_PATH_PARTS for part in py_file.parts)
+    )

--- a/determystic/validators/exception_coverage.py
+++ b/determystic/validators/exception_coverage.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from determystic.configs.project import ProjectConfigManager
+from determystic.path_filters import is_test_file, iter_python_files
 from determystic.validators.base import BaseValidator, ValidationResult
 
 
@@ -16,7 +17,6 @@ MARKER_NAMES = {
     "test-exception",
     "test-exceptions",
 }
-TEST_PATH_PARTS = {"tests", "__tests__"}
 
 
 @dataclass(frozen=True)
@@ -148,13 +148,20 @@ class TestFunctionCollector(ast.NodeVisitor):
 class ExceptionCoverageValidator(BaseValidator):
     """Validator that ensures production except handlers are covered by test markers."""
 
-    def __init__(self, *, name: str = "exception_coverage", path: Path | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        name: str = "exception_coverage",
+        path: Path | None = None,
+        ignore_paths: list[str] | None = None,
+    ) -> None:
         super().__init__(name=name, path=path)
+        self.ignore_paths = ignore_paths or []
 
     @classmethod
     def create_validators(cls, config_manager: ProjectConfigManager) -> list["BaseValidator"]:
         """Factory function that creates a single exception coverage validator."""
-        return [cls(path=config_manager.project_root)]
+        return [cls(path=config_manager.project_root, ignore_paths=config_manager.ignore_paths)]
 
     async def validate(self) -> ValidationResult:
         """Validate exception handler coverage markers across the project."""
@@ -172,17 +179,13 @@ class ExceptionCoverageValidator(BaseValidator):
         return ValidationResult(success=False, output="\n".join(issues))
 
     def _get_production_python_files(self, path: Path) -> list[Path]:
-        return [
-            py_file
-            for py_file in path.rglob("*.py")
-            if _is_relevant_python_file(py_file) and not _is_test_file(py_file)
-        ]
+        return iter_python_files(path, self.ignore_paths, include_tests=False)
 
     def _get_test_python_files(self, path: Path) -> list[Path]:
         return [
             py_file
-            for py_file in path.rglob("*.py")
-            if _is_relevant_python_file(py_file) and _is_test_file(py_file)
+            for py_file in iter_python_files(path, self.ignore_paths)
+            if is_test_file(py_file)
         ]
 
     def _collect_requirements(self, python_files: list[Path]) -> list[ExceptionRequirement]:
@@ -490,18 +493,3 @@ def _module_name_for_file(py_file: Path, project_root: Path) -> str:
     if parts and parts[-1] == "__init__":
         parts = parts[:-1]
     return ".".join(parts) if parts else py_file.stem
-
-
-def _is_relevant_python_file(py_file: Path) -> bool:
-    return (
-        not any(part.startswith(".") for part in py_file.parts)
-        and "__pycache__" not in py_file.parts
-    )
-
-
-def _is_test_file(py_file: Path) -> bool:
-    return (
-        py_file.name.startswith("test_")
-        or py_file.name.endswith("_test.py")
-        or any(part in TEST_PATH_PARTS for part in py_file.parts)
-    )

--- a/determystic/validators/function_visibility.py
+++ b/determystic/validators/function_visibility.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from determystic.configs.project import ProjectConfigManager
+from determystic.path_filters import iter_python_files
 from determystic.suppressions import SuppressionComments
 from determystic.validators.base import BaseValidator, ValidationResult
 
@@ -426,13 +427,20 @@ class ReferenceCollector(ast.NodeVisitor):
 class FunctionVisibilityValidator(BaseValidator):
     """Validate function visibility naming and ordering."""
 
-    def __init__(self, *, name: str = "function_visibility", path: Path | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        name: str = "function_visibility",
+        path: Path | None = None,
+        ignore_paths: list[str] | None = None,
+    ) -> None:
         super().__init__(name=name, path=path)
+        self.ignore_paths = ignore_paths or []
 
     @classmethod
     def create_validators(cls, config_manager: ProjectConfigManager) -> list["BaseValidator"]:
         """Create the built-in function visibility validator."""
-        return [cls(path=config_manager.project_root)]
+        return [cls(path=config_manager.project_root, ignore_paths=config_manager.ignore_paths)]
 
     async def validate(self) -> ValidationResult:
         """Validate function visibility across the project."""
@@ -455,27 +463,7 @@ class FunctionVisibilityValidator(BaseValidator):
 
     def _get_python_files(self, path: Path) -> list[Path]:
         """Get Python files that should be included in project analysis."""
-        python_files = list(path.rglob("*.py"))
-        filtered_files = []
-
-        for py_file in python_files:
-            if any(part.startswith(".") for part in py_file.parts):
-                continue
-            if "__pycache__" in py_file.parts:
-                continue
-
-            file_name = py_file.name
-            if (
-                file_name.startswith("test_")
-                or file_name.endswith("_test.py")
-                or "__tests__" in py_file.parts
-                or "tests" in py_file.parts
-            ):
-                continue
-
-            filtered_files.append(py_file)
-
-        return filtered_files
+        return iter_python_files(path, self.ignore_paths, include_tests=False)
 
     def _build_project_index(self, python_files: list[Path]) -> ProjectIndex:
         modules_by_path: dict[str, ModuleInfo] = {}

--- a/determystic/validators/hanging_functions.py
+++ b/determystic/validators/hanging_functions.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from determystic.configs.project import ProjectConfigManager
+from determystic.path_filters import iter_python_files
 from determystic.suppressions import SuppressionComments
 from determystic.validators.base import BaseValidator, ValidationResult
 
@@ -275,13 +276,20 @@ class UnreachableCodeCollector(ast.NodeVisitor):
 class HangingFunctionsValidator(BaseValidator):
     """Validator that detects unused definitions, arguments, and unreachable code."""
 
-    def __init__(self, *, name: str = "hanging_functions", path: Path | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        name: str = "hanging_functions",
+        path: Path | None = None,
+        ignore_paths: list[str] | None = None,
+    ) -> None:
         super().__init__(name=name, path=path)
+        self.ignore_paths = ignore_paths or []
 
     @classmethod
     def create_validators(cls, config_manager: ProjectConfigManager) -> list["BaseValidator"]:
         """Factory function that creates a single dead-code validator instance."""
-        return [cls(path=config_manager.project_root)]
+        return [cls(path=config_manager.project_root, ignore_paths=config_manager.ignore_paths)]
 
     async def validate(self) -> ValidationResult:
         """Validate the codebase for dead code."""
@@ -344,27 +352,7 @@ class HangingFunctionsValidator(BaseValidator):
 
     def _get_python_files(self, path: Path) -> list[Path]:
         """Get all Python files, excluding test files and hidden directories."""
-        python_files = list(path.rglob("*.py"))
-
-        filtered_files = []
-        for py_file in python_files:
-            if any(part.startswith(".") for part in py_file.parts):
-                continue
-            if "__pycache__" in py_file.parts:
-                continue
-
-            file_name = py_file.name
-            if (
-                file_name.startswith("test_")
-                or file_name.endswith("_test.py")
-                or "__tests__" in py_file.parts
-                or "tests" in py_file.parts
-            ):
-                continue
-
-            filtered_files.append(py_file)
-
-        return filtered_files
+        return iter_python_files(path, self.ignore_paths, include_tests=False)
 
     def _get_script_entrypoints(self, path: Path) -> set[str]:
         """Extract script entrypoint function names from pyproject.toml."""

--- a/determystic/validators/static_analysis.py
+++ b/determystic/validators/static_analysis.py
@@ -22,9 +22,22 @@ class StaticAnalysisValidator(BaseValidator):
     
     @classmethod
     def create_validators(cls, config_manager: ProjectConfigManager) -> list[BaseValidator]:
+        ruff_command = [
+            "ruff",
+            "check",
+            str(config_manager.project_root),
+            "--no-fix",
+            *_ruff_ignore_args(config_manager.ignore_paths),
+        ]
+        ty_command = [
+            "ty",
+            "check",
+            str(config_manager.project_root),
+            *_ty_ignore_args(config_manager.ignore_paths),
+        ]
         return [
-            cls(config_manager.project_root, ["ruff", "check", str(config_manager.project_root), "--no-fix"]),
-            cls(config_manager.project_root, ["ty", "check", str(config_manager.project_root)])
+            cls(config_manager.project_root, ruff_command),
+            cls(config_manager.project_root, ty_command),
         ]   
     
     async def validate(self) -> ValidationResult:
@@ -41,3 +54,29 @@ class StaticAnalysisValidator(BaseValidator):
             success=process.returncode == 0,
             output=stdout.decode() if stdout else stderr.decode()
         )
+
+
+def _ruff_ignore_args(ignore_paths: list[str]) -> list[str]:
+    args: list[str] = []
+    for ignore_path in ignore_paths:
+        if not ignore_path.strip():
+            continue
+        args.extend(["--extend-exclude", _normalize_cli_ignore_path(ignore_path)])
+    if args:
+        args.append("--force-exclude")
+    return args
+
+
+def _ty_ignore_args(ignore_paths: list[str]) -> list[str]:
+    args: list[str] = []
+    for ignore_path in ignore_paths:
+        if not ignore_path.strip():
+            continue
+        args.extend(["--exclude", _normalize_cli_ignore_path(ignore_path)])
+    if args:
+        args.append("--force-exclude")
+    return args
+
+
+def _normalize_cli_ignore_path(ignore_path: str) -> str:
+    return ignore_path.strip().replace("\\", "/")


### PR DESCRIPTION
Agents will have a tendency to overly wrap logic with try/except blocks. This is okay _if_ we have done so because we have explicit proof of the failure mode (typically in a reproduction case). But more common than not this code just sticks around in the codebase and people are afraid to remove it because it might have been put there for a purpose but no one is sure why.

This new validator requires all try/except statements to have documented examples in the unit tests (self-reported with comments) that will reproduce the exception.