### PR TITLE
Fix use of determystic from relative path imports

### DIFF
--- a/determystic/__tests__/test_isolated_env.py
+++ b/determystic/__tests__/test_isolated_env.py
@@ -1,9 +1,11 @@
 """Tests for isolated agent test execution."""
 
+import os
 import subprocess
+from importlib import metadata
 from unittest.mock import patch
 
-from determystic.isolated_env import IsolatedEnv
+from determystic.isolated_env import IsolatedEnv, _installed_determystic_runtime_dependencies
 
 
 # determystic: tested-exceptions[determystic.isolated_env.IsolatedEnv.run_tests: TimeoutExpired]
@@ -38,3 +40,86 @@ def test_run_tests_reports_unexpected_errors() -> None:
 
     assert success is False
     assert "Unexpected error running tests: package setup failed" in output
+
+
+def test_create_test_package_uses_source_dependency_when_project_root_exists(tmp_path) -> None:
+    """Source checkouts should install determystic from the local project root."""
+    source_root = tmp_path / "source"
+    source_root.mkdir()
+    (source_root / "pyproject.toml").write_text("[project]\nname = \"determystic\"\n")
+
+    env = IsolatedEnv()
+    env.temp_dir = tmp_path
+    env.determystic_package_path = source_root
+
+    package_dir = env._create_test_package("validator", "tests")
+    pyproject = (package_dir / "pyproject.toml").read_text()
+
+    assert f"determystic @ file://{source_root.absolute()}" in pyproject
+    assert not (package_dir / "determystic").exists()
+
+
+def test_create_test_package_uses_import_path_when_no_project_root(tmp_path) -> None:
+    """Installed uvx-style packages should not be treated as installable source roots."""
+    site_packages = tmp_path / "site-packages"
+    package_source = site_packages / "determystic"
+    package_source.mkdir(parents=True)
+    (package_source / "__init__.py").write_text("")
+    (package_source / "external.py").write_text("class DeterministicTraverser: pass\n")
+
+    env = IsolatedEnv()
+    env.temp_dir = tmp_path
+    env.determystic_package_path = site_packages
+
+    with patch(
+        "determystic.isolated_env._installed_determystic_runtime_dependencies",
+        return_value=["pydantic>=2.0.0"],
+    ):
+        package_dir = env._create_test_package("validator", "tests")
+
+    pyproject = (package_dir / "pyproject.toml").read_text()
+
+    assert "determystic @ file://" not in pyproject
+    assert '"pydantic>=2.0.0"' in pyproject
+    assert not (package_dir / "determystic").exists()
+
+
+def test_run_tests_adds_installed_package_parent_to_pythonpath(tmp_path) -> None:
+    """uvx-style runs should import determystic from the currently running package path."""
+    site_packages = tmp_path / "site-packages"
+    env = IsolatedEnv()
+    env.temp_dir = tmp_path
+    env.determystic_package_path = site_packages
+
+    completed = subprocess.CompletedProcess(
+        args=["uv", "run", "pytest"],
+        returncode=0,
+        stdout="tests passed",
+        stderr="",
+    )
+
+    with (
+        patch(
+            "determystic.isolated_env._installed_determystic_runtime_dependencies",
+            return_value=["pydantic>=2.0.0"],
+        ),
+        patch("determystic.isolated_env.subprocess.run", return_value=completed) as mock_run,
+    ):
+        success, output = env.run_tests("validator", "tests")
+
+    run_env = mock_run.call_args.kwargs["env"]
+    pythonpath_entries = run_env["PYTHONPATH"].split(os.pathsep)
+
+    assert success is True
+    assert output == "tests passed"
+    assert pythonpath_entries[0] == str(site_packages.absolute())
+
+
+# determystic: tested-exceptions[determystic.isolated_env._installed_determystic_runtime_dependencies: metadata.PackageNotFoundError]
+def test_installed_determystic_runtime_dependencies_falls_back_when_metadata_is_missing() -> None:
+    """Missing installed metadata should still provide the minimal runtime dependency."""
+    with patch(
+        "determystic.isolated_env.metadata.distribution",
+        side_effect=metadata.PackageNotFoundError,
+    ):
+        assert _installed_determystic_runtime_dependencies() == ["pydantic>=2.0.0"]

--- a/determystic/__tests__/test_isolated_env.py
+++ b/determystic/__tests__/test_isolated_env.py
@@ -2,10 +2,9 @@
 
 import os
 import subprocess
-from importlib import metadata
 from unittest.mock import patch
 
-from determystic.isolated_env import IsolatedEnv, _installed_determystic_runtime_dependencies
+from determystic.isolated_env import IsolatedEnv
 
 
 # determystic: tested-exceptions[determystic.isolated_env.IsolatedEnv.run_tests: TimeoutExpired]
@@ -71,16 +70,12 @@ def test_create_test_package_uses_import_path_when_no_project_root(tmp_path) -> 
     env.temp_dir = tmp_path
     env.determystic_package_path = site_packages
 
-    with patch(
-        "determystic.isolated_env._installed_determystic_runtime_dependencies",
-        return_value=["pydantic>=2.0.0"],
-    ):
-        package_dir = env._create_test_package("validator", "tests")
+    package_dir = env._create_test_package("validator", "tests")
 
     pyproject = (package_dir / "pyproject.toml").read_text()
 
     assert "determystic @ file://" not in pyproject
-    assert '"pydantic>=2.0.0"' in pyproject
+    assert '"pytest>=6.0"' in pyproject
     assert not (package_dir / "determystic").exists()
 
 
@@ -98,13 +93,7 @@ def test_run_tests_adds_installed_package_parent_to_pythonpath(tmp_path) -> None
         stderr="",
     )
 
-    with (
-        patch(
-            "determystic.isolated_env._installed_determystic_runtime_dependencies",
-            return_value=["pydantic>=2.0.0"],
-        ),
-        patch("determystic.isolated_env.subprocess.run", return_value=completed) as mock_run,
-    ):
+    with patch("determystic.isolated_env.subprocess.run", return_value=completed) as mock_run:
         success, output = env.run_tests("validator", "tests")
 
     run_env = mock_run.call_args.kwargs["env"]
@@ -113,13 +102,3 @@ def test_run_tests_adds_installed_package_parent_to_pythonpath(tmp_path) -> None
     assert success is True
     assert output == "tests passed"
     assert pythonpath_entries[0] == str(site_packages.absolute())
-
-
-# determystic: tested-exceptions[determystic.isolated_env._installed_determystic_runtime_dependencies: metadata.PackageNotFoundError]
-def test_installed_determystic_runtime_dependencies_falls_back_when_metadata_is_missing() -> None:
-    """Missing installed metadata should still provide the minimal runtime dependency."""
-    with patch(
-        "determystic.isolated_env.metadata.distribution",
-        side_effect=metadata.PackageNotFoundError,
-    ):
-        assert _installed_determystic_runtime_dependencies() == ["pydantic>=2.0.0"]

--- a/determystic/isolated_env.py
+++ b/determystic/isolated_env.py
@@ -5,7 +5,6 @@ import os
 import shutil
 import subprocess
 import tempfile
-from importlib import metadata
 from pathlib import Path
 from typing import Optional
 
@@ -122,17 +121,13 @@ where = ["."]
 
     def _dependency_specs(self) -> list[str]:
         """Build dependency specs for the temporary pytest project."""
-        specs = ["pytest>=6.0"]
-
         if self._has_installable_determystic_source():
-            specs.insert(
-                0,
+            return [
                 f"determystic @ file://{self.determystic_package_path.absolute()}",
-            )
-            return specs
+                "pytest>=6.0",
+            ]
 
-        specs.extend(_installed_determystic_runtime_dependencies())
-        return _dedupe_dependency_specs(specs)
+        return ["pytest>=6.0"]
 
     def _subprocess_env(self) -> dict[str, str]:
         """Build the subprocess environment for the isolated pytest run."""
@@ -148,25 +143,3 @@ where = ["."]
             else package_parent
         )
         return env
-
-
-def _installed_determystic_runtime_dependencies() -> list[str]:
-    """Return runtime dependency specs from installed package metadata."""
-    try:
-        dist = metadata.distribution("determystic")
-    except metadata.PackageNotFoundError:
-        return ["pydantic>=2.0.0"]
-
-    return list(dist.requires or []) or ["pydantic>=2.0.0"]
-
-
-def _dedupe_dependency_specs(specs: list[str]) -> list[str]:
-    """Deduplicate dependency specs while preserving order."""
-    seen: set[str] = set()
-    deduped: list[str] = []
-    for spec in specs:
-        if spec in seen:
-            continue
-        seen.add(spec)
-        deduped.append(spec)
-    return deduped

--- a/determystic/isolated_env.py
+++ b/determystic/isolated_env.py
@@ -1,10 +1,13 @@
 """Isolated environment runner for agent test execution."""
 
-import tempfile
+import json
+import os
+import shutil
 import subprocess
+import tempfile
+from importlib import metadata
 from pathlib import Path
 from typing import Optional
-import shutil
 
 from determystic.io import get_determystic_package_path
 
@@ -44,10 +47,12 @@ class IsolatedEnv:
         try:
             # Create the temporary package
             package_dir = self._create_test_package(validator_code, test_code)
+            env = self._subprocess_env()
             
             result = subprocess.run(
                 ["uv", "run", "pytest", "test_validator.py", "-v"],
                 cwd=package_dir,
+                env=env,
                 capture_output=True,
                 text=True,
                 timeout=30
@@ -81,7 +86,10 @@ class IsolatedEnv:
         package_dir = self.temp_dir / "temp_validator"
         package_dir.mkdir(parents=True)
 
-        # Create pyproject.toml with local determystic dependency
+        dependency_specs = self._dependency_specs()
+        dependency_lines = ",\n".join(f"    {json.dumps(spec)}" for spec in dependency_specs)
+
+        # Create pyproject.toml with the dependencies needed by generated tests.
         pyproject_content = f'''[build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
@@ -90,8 +98,7 @@ build-backend = "setuptools.build_meta"
 name = "temp-validator"
 version = "0.1.0"
 dependencies = [
-    "determystic @ file://{self.determystic_package_path.absolute()}",
-    "pytest>=6.0"
+{dependency_lines}
 ]
 
 [tool.setuptools.packages.find]
@@ -107,3 +114,59 @@ where = ["."]
         (package_dir / "test_validator.py").write_text(test_code)
 
         return package_dir
+
+    def _has_installable_determystic_source(self) -> bool:
+        """Return whether the resolved path can be installed as a Python project."""
+        root = self.determystic_package_path
+        return (root / "pyproject.toml").exists() or (root / "setup.py").exists()
+
+    def _dependency_specs(self) -> list[str]:
+        """Build dependency specs for the temporary pytest project."""
+        specs = ["pytest>=6.0"]
+
+        if self._has_installable_determystic_source():
+            specs.insert(
+                0,
+                f"determystic @ file://{self.determystic_package_path.absolute()}",
+            )
+            return specs
+
+        specs.extend(_installed_determystic_runtime_dependencies())
+        return _dedupe_dependency_specs(specs)
+
+    def _subprocess_env(self) -> dict[str, str]:
+        """Build the subprocess environment for the isolated pytest run."""
+        env = os.environ.copy()
+        if self._has_installable_determystic_source():
+            return env
+
+        package_parent = str(self.determystic_package_path.absolute())
+        existing_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            f"{package_parent}{os.pathsep}{existing_pythonpath}"
+            if existing_pythonpath
+            else package_parent
+        )
+        return env
+
+
+def _installed_determystic_runtime_dependencies() -> list[str]:
+    """Return runtime dependency specs from installed package metadata."""
+    try:
+        dist = metadata.distribution("determystic")
+    except metadata.PackageNotFoundError:
+        return ["pydantic>=2.0.0"]
+
+    return list(dist.requires or []) or ["pydantic>=2.0.0"]
+
+
+def _dedupe_dependency_specs(specs: list[str]) -> list[str]:
+    """Deduplicate dependency specs while preserving order."""
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for spec in specs:
+        if spec in seen:
+            continue
+        seen.add(spec)
+        deduped.append(spec)
+    return deduped


### PR DESCRIPTION
Determystic is currently failing when run via uvx because it relies on relative paths to pyproject that isn't there. This PR should fix that issue.